### PR TITLE
Fix schema inference for delimited text uploads

### DIFF
--- a/docs/dev_docs/data-model/tabular-validator.md
+++ b/docs/dev_docs/data-model/tabular-validator.md
@@ -55,10 +55,15 @@ as counting newlines, because a quoted field may legitimately contain a newline.
 
 The delimiter is decided, not guessed-and-hoped. If the settings declare one,
 that declaration is authoritative. If nothing is declared, the reader sniffs
-the delimiter from a bounded sample of the file. If a declaration and a sniff
-disagree, the read fails with a clear message rather than silently preferring
-one — an honest "you said comma, this looks tab-delimited" beats a wrong guess
-that would mis-parse every row.
+comma, tab, semicolon, and pipe delimiters from a bounded sample of the file.
+The filename and MIME type are not inputs to this decision. If the standard
+sniffer cannot decide, a bounded fallback looks for one unambiguous delimiter
+that gives every sampled logical record the same multi-column width. Ambiguous
+content fails with guidance to select the delimiter explicitly instead of
+silently becoming a one-column schema. If a declaration and a sniff disagree,
+the read fails with a clear message rather than silently preferring one — an
+honest "you said comma, this looks tab-delimited" beats a wrong guess that
+would mis-parse every row.
 
 ## Column names: one canonical name per column
 
@@ -70,7 +75,8 @@ this precedence:
    must be safe to address: a blank name, a duplicate name, or two names that
    collide ignoring case (`Lat` vs `lat`) all fail by default, because
    `row.*` keys come from these names and an ambiguous header would make a
-   reference silently wrong.
+   reference silently wrong. A name longer than 255 characters also fails so a
+   hostile header cannot inflate generated schemas and editor responses.
 2. **Headerless file with a declared name for that position** → the declared
    name (aligned by position).
 3. **Headerless file with no declared name** → a synthesised `column_1`,
@@ -314,7 +320,15 @@ run with a clear finding; it never silently truncates.
 |-----|---------|-------------|
 | File size | 50 MB | PREFLIGHT (before the load) |
 | Columns | 1,024 | PREFLIGHT (from the first record) |
+| Header name | 255 characters | READ (before the dataframe load) |
 | Rows | 1,000,000 | READ |
+
+Schema inference applies tighter authoring-path limits: a sample file is at
+most 5 MB, the complete multipart request is at most 10 MB, only the first
+1,000 data rows are sampled, and the serialized proposal is at most 2 MB. The
+request-size check runs before Django parses `request.FILES`, while the file
+check bounds decoding and dataframe work. Inference never stores the uploaded
+sample; only the reviewed descriptor is eligible to be applied.
 
 ## Where the code lives
 

--- a/docs/help_pages/validators/tabular-validator.md
+++ b/docs/help_pages/validators/tabular-validator.md
@@ -47,13 +47,15 @@ below.
 
 When you configure a Tabular step you can build the column schema three ways:
 
-1. **Infer it from a sample file (the quick path).** Upload a representative
-   CSV and select **Infer columns**. Validibot reads the header, resolves the
-   delimiter, and guesses each column's type from its values. Review the
-   proposal, then select **Apply proposed schema**. Your current unsaved
-   columns are not replaced until you apply it. Inference picks types only, so
-   add the ranges, allowed values, and required flags that matter for your
-   check.
+1. **Infer it from a sample file (the quick path).** Upload representative
+   delimited text and select **Infer columns**. The filename extension does not
+   matter: Validibot reads the content, detects comma, tab, semicolon, or pipe
+   delimiters, reads the header, and guesses each column's type from its
+   values. If detection is ambiguous, select the delimiter explicitly and try
+   again. Review the proposal, then select **Apply proposed schema**. Your
+   current unsaved columns are not replaced until you apply it. Inference picks
+   types only, so add the ranges, allowed values, and required flags that
+   matter for your check.
 2. **Import a descriptor.** Paste or upload a Frictionless Table Schema JSON
    descriptor and select **Import schema**. Validibot shows a compatibility
    report and proposal before replacing the current editor. Unsupported

--- a/validibot/templates/workflows/partials/tabular_infer_modal.html
+++ b/validibot/templates/workflows/partials/tabular_infer_modal.html
@@ -3,10 +3,11 @@
 {% comment %}
 "Infer from Sample" modal — a two-screen wizard launched from the page header.
 
-Screen 1 (input): upload a representative CSV. The "Infer columns" submit posts
-to the infer endpoint; on success the endpoint returns the review body + an
-HX-Trigger flipping the modal to screen 2 (and out-of-band swaps for the
-detected dialect), and on failure it HX-Retargets the error onto this screen.
+Screen 1 (input): upload representative delimited text. The "Infer columns"
+submit posts to the infer endpoint; on success the endpoint returns the review
+body + an HX-Trigger flipping the modal to screen 2 (and out-of-band swaps for
+the detected dialect), and on failure it HX-Retargets the error onto this
+screen.
 
 Screen 2 (review): the compatibility report + column-count summary, with Apply
 (replace the columns and close), Back (return to input), and Cancel.
@@ -40,14 +41,13 @@ Screen switching, Back, and Apply-close are wired in tabular_step_settings.html.
           </button>
         </div>
         <div class="modal-body">
-          <label class="form-label" for="id_sample_file">{% trans "Sample CSV" %}</label>
+          <label class="form-label" for="id_sample_file">{% trans "Delimited text sample" %}</label>
           <input type="file"
                  name="sample_file"
                  id="id_sample_file"
-                 class="form-control"
-                 accept=".csv,.tsv,text/csv,text/tab-separated-values" />
+                 class="form-control" />
           <p class="form-text">
-            {% trans "Your current columns are kept until you apply the proposal." %}
+            {% trans "Comma, tab, semicolon, and pipe delimiters are supported. The filename extension does not matter. Your current columns are kept until you apply the proposal." %}
           </p>
           <div id="tabular-infer-input-error">
           </div>

--- a/validibot/validations/tests/test_validators/test_tabular_infer.py
+++ b/validibot/validations/tests/test_validators/test_tabular_infer.py
@@ -4,9 +4,9 @@ Tests for the Tabular Validator's schema inference
 
 ### What this suite covers and why
 
-Inferring a schema from a sample CSV is the fastest setup path — "drop a file,
-get a Table Schema to tighten." The behaviours pinned here are the ones that
-make the inferred schema trustworthy as a starting point:
+Inferring a schema from delimited text is the fastest setup path — "drop a
+file, get a Table Schema to tighten." The behaviours pinned here are the ones
+that make the inferred schema trustworthy as a starting point:
 
 - **Type guessing is locale-free and reuses the validator's coercion**, so an
   inferred type means what validation will enforce.
@@ -22,8 +22,13 @@ Pure functions (no DB) → ``SimpleTestCase``.
 
 from __future__ import annotations
 
+import pytest
 from django.test import SimpleTestCase
 
+from validibot.validations.validators.tabular.infer import (
+    CODE_INFERRED_SCHEMA_TOO_LARGE,
+)
+from validibot.validations.validators.tabular.infer import InferenceError
 from validibot.validations.validators.tabular.infer import infer_table_schema
 from validibot.validations.validators.tabular.preflight import TabularDialect
 from validibot.validations.validators.tabular.schema import parse_table_schema
@@ -125,3 +130,20 @@ class InferSamplingTests(SimpleTestCase):
         # Full read would infer string (mixed); sampling 1 row sees only "1".
         result = infer_table_schema(b"n\n1\nabc\n", sample_rows=1)
         self.assertEqual(_types(result)["n"], "integer")
+
+    def test_serialized_descriptor_size_is_bounded(self):
+        """Inference rejects a proposal that would exceed its response cap.
+
+        Header-length and column-count limits provide the normal protection;
+        this independent serialized-size check is defence in depth for Unicode
+        expansion and future descriptor fields.
+        """
+        with pytest.raises(InferenceError) as exc_info:
+            infer_table_schema(
+                b"first,second\n1,2\n",
+                max_schema_bytes=20,
+            )
+        self.assertEqual(
+            exc_info.value.code,
+            CODE_INFERRED_SCHEMA_TOO_LARGE,
+        )

--- a/validibot/validations/tests/test_validators/test_tabular_native.py
+++ b/validibot/validations/tests/test_validators/test_tabular_native.py
@@ -216,6 +216,21 @@ class TableSchemaParseTests(SimpleTestCase):
                 {"fields": [{"name": "Lat"}, {"name": "lat"}]},
             )
 
+    def test_overlong_field_name_rejected(self):
+        """Imported schemas obey the same field-name bound as file headers.
+
+        Otherwise an author could bypass the inference guard by importing a
+        descriptor whose names later inflate the editor and validation UI.
+        """
+        names = ("x" * 256, (" " * 255) + "x")
+        for name in names:
+            name_kind = "whitespace" if name.startswith(" ") else "text"
+            with (
+                self.subTest(name_kind=name_kind),
+                pytest.raises(ValueError, match="character limit"),
+            ):
+                parse_table_schema({"fields": [{"name": name}]})
+
 
 # ─────────────────────────────────────────────────────────────────────
 # Cell coercion

--- a/validibot/validations/tests/test_validators/test_tabular_reader.py
+++ b/validibot/validations/tests/test_validators/test_tabular_reader.py
@@ -31,10 +31,14 @@ is the stable machine-readable contract the validator emits as a finding.
 
 from __future__ import annotations
 
+import csv
+from unittest.mock import patch
+
 import pytest
 from django.test import SimpleTestCase
 
 from validibot.validations.validators.tabular.preflight import CODE_DIALECT_MISMATCH
+from validibot.validations.validators.tabular.preflight import CODE_DIALECT_UNDETERMINED
 from validibot.validations.validators.tabular.preflight import CODE_EMPTY_FILE
 from validibot.validations.validators.tabular.preflight import CODE_ENCODING_ERROR
 from validibot.validations.validators.tabular.preflight import CODE_FILE_TOO_LARGE
@@ -47,6 +51,9 @@ from validibot.validations.validators.tabular.readers.csv import CODE_BLANK_HEAD
 from validibot.validations.validators.tabular.readers.csv import CODE_DUPLICATE_HEADER
 from validibot.validations.validators.tabular.readers.csv import (
     CODE_HEADER_CASE_COLLISION,
+)
+from validibot.validations.validators.tabular.readers.csv import (
+    CODE_HEADER_NAME_TOO_LONG,
 )
 from validibot.validations.validators.tabular.readers.csv import CODE_PARSE_ERROR
 from validibot.validations.validators.tabular.readers.csv import CODE_TOO_MANY_ROWS
@@ -116,6 +123,90 @@ class PreflightTests(SimpleTestCase):
         result = run_preflight(b"a\tb\tc\n1\t2\t3\n4\t5\t6\n")
         self.assertEqual(result.delimiter, "\t")
         self.assertEqual(result.field_count, 3)
+
+    def test_each_supported_delimiter_is_detected_from_content(self):
+        """Comma, tab, semicolon, and pipe all work without filename hints.
+
+        Keeping the complete supported set in one table-driven test prevents a
+        future sniffing change from accidentally narrowing inference to the two
+        most common dialects.
+        """
+        samples = {
+            ",": b"a,b\n1,2\n",
+            "\t": b"a\tb\n1\t2\n",
+            ";": b"a;b\n1;2\n",
+            "|": b"a|b\n1|2\n",
+        }
+        for expected, content in samples.items():
+            with self.subTest(delimiter=repr(expected)):
+                result = run_preflight(content)
+                self.assertEqual(result.delimiter, expected)
+                self.assertEqual(result.field_count, 2)
+
+    def test_quoted_punctuation_does_not_create_false_ambiguity(self):
+        """Supported delimiter characters inside quoted cells remain data.
+
+        A comma-delimited export may legitimately contain tabs, semicolons, or
+        pipes in text values; quote-aware candidate parsing must not mistake
+        those characters for competing dialects.
+        """
+        content = b'a,b\n1,"tab\tpipe|semicolon;"\n2,"plain"\n'
+        result = run_preflight(content)
+        self.assertEqual(result.delimiter, ",")
+        self.assertEqual(result.field_count, 2)
+
+    def test_consistent_width_fallback_detects_tab_delimiter(self):
+        """A valid TSV remains detectable when ``csv.Sniffer`` gives up.
+
+        Real-world generated exports can defeat the heuristic sniffer because
+        their values contain varied punctuation. The bounded fallback parses
+        logical records with each supported delimiter and accepts the one
+        unambiguous, consistent multi-column shape.
+        """
+        content = b"id\tscientificName\tdepth\n1\tA, alpha\t10\n2\tB|beta\t20\n"
+        with patch(
+            "validibot.validations.validators.tabular.preflight.csv.Sniffer.sniff",
+            side_effect=csv.Error,
+        ):
+            result = run_preflight(content)
+        self.assertEqual(result.delimiter, "\t")
+        self.assertEqual(result.field_count, 3)
+
+    def test_ambiguous_fallback_requires_explicit_delimiter(self):
+        """Equally plausible delimiters fail instead of becoming one column.
+
+        When automatic detection has no defensible answer, asking the author
+        to select a delimiter is safer than silently falling back to comma and
+        proposing a misleading schema.
+        """
+        content = b"a\tb,c\n1\t2,3\n"
+        with pytest.raises(PreflightError) as exc_info:
+            run_preflight(content)
+        self.assertEqual(exc_info.value.code, CODE_DIALECT_UNDETERMINED)
+
+    def test_explicit_delimiter_resolves_ambiguous_content(self):
+        """The author's explicit selection resolves an automatic-detect tie.
+
+        The ambiguity error is actionable rather than a dead end: selecting tab
+        makes the same bytes parse deterministically as the intended table.
+        """
+        content = b"a\tb,c\n1\t2,3\n"
+        result = run_preflight(
+            content,
+            dialect=TabularDialect(delimiter="\t"),
+        )
+        self.assertEqual(result.delimiter, "\t")
+        self.assertEqual(result.field_count, 2)
+
+    def test_single_column_without_delimiter_remains_valid(self):
+        """No delimiter at all is a legitimate one-column table.
+
+        Ambiguity protection must not reject a plain list merely because the
+        internal reader needs a dialect value; comma remains the inert default.
+        """
+        result = run_preflight(b"occurrenceID\nurn:one\nurn:two\n")
+        self.assertEqual(result.delimiter, ",")
+        self.assertEqual(result.field_count, 1)
 
     def test_too_many_columns_rejected(self):
         """A file wider than the column cap is rejected in PREFLIGHT, from
@@ -310,3 +401,14 @@ class UnsafeHeaderTests(SimpleTestCase):
         with pytest.raises(ParseError) as exc_info:
             read_csv(b"Lat,lat\n1,2\n")
         self.assertEqual(exc_info.value.code, CODE_HEADER_CASE_COLLISION)
+
+    def test_overlong_header_name_fails_before_schema_generation(self):
+        """A huge header cell cannot inflate an inferred or stored schema.
+
+        The test uses a deliberately small custom limit to exercise the same
+        parser guard without constructing a large fixture.
+        """
+        limits = TabularLimits(max_header_name_chars=8)
+        with pytest.raises(ParseError) as exc_info:
+            read_csv(b"occurrenceID,value\nurn:one,1\n", limits=limits)
+        self.assertEqual(exc_info.value.code, CODE_HEADER_NAME_TOO_LONG)

--- a/validibot/validations/validators/tabular/infer.py
+++ b/validibot/validations/validators/tabular/infer.py
@@ -1,10 +1,11 @@
 """Schema inference — "drop a sample → get a Table Schema to edit".
 
-Most target users have a *sample CSV*, not a hand-written Frictionless
-descriptor, so inferring a starting schema from a sample is the fastest common
-setup path (and, per ADR-2026-05-26, likely the single highest-value setup
-feature). This module reads a bounded sample, resolves the dialect and column
-names via the normal reader, and guesses each column's type from its values.
+Most target users have a *delimited text sample*, not a hand-written
+Frictionless descriptor, so inferring a starting schema from a sample is the
+fastest common setup path (and, per ADR-2026-05-26, likely the single
+highest-value setup feature). This module reads bounded content regardless of
+its filename extension, resolves the dialect and column names via the normal
+reader, and guesses each column's type from its values.
 
 The result is a *starting point* the author tightens in the settings editor —
 inference picks a type, the author adds the ``min``/``max``/``enum``/``required``
@@ -23,16 +24,24 @@ as integer, not boolean), ``"1.5"`` is ``number``, ``"true"``/``"false"`` is
 
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass
 
 from validibot.validations.validators.tabular.coercion import coerce_cell
 from validibot.validations.validators.tabular.preflight import TabularDialect
 from validibot.validations.validators.tabular.preflight import TabularLimits
+from validibot.validations.validators.tabular.preflight import TabularReadError
 from validibot.validations.validators.tabular.readers.csv import read_csv
 
 # Default number of rows sampled for inference. Enough to type columns
 # confidently without reading a whole large file.
 DEFAULT_SAMPLE_ROWS = 1000
+
+# Inferred descriptors are returned through a hidden form field before the
+# author applies them. Bound the serialized result so hostile header names
+# cannot inflate that response or a subsequently stored ruleset.
+DEFAULT_MAX_SCHEMA_BYTES = 2 * 1024 * 1024
+CODE_INFERRED_SCHEMA_TOO_LARGE = "tabular.inferred_schema_too_large"
 
 # Candidate types tried in order; the first that *all* non-empty values satisfy
 # wins. ``string`` is the implicit fallback when none match.
@@ -51,6 +60,10 @@ class InferredSchema:
 
     descriptor: dict
     dialect: TabularDialect
+
+
+class InferenceError(TabularReadError):
+    """A bounded schema-inference failure after the sample was parsed."""
 
 
 def _infer_column_type(values: list[str]) -> str:
@@ -76,6 +89,7 @@ def infer_table_schema(
     dialect: TabularDialect | None = None,
     limits: TabularLimits | None = None,
     sample_rows: int = DEFAULT_SAMPLE_ROWS,
+    max_schema_bytes: int = DEFAULT_MAX_SCHEMA_BYTES,
 ) -> InferredSchema:
     """Infer a Table Schema descriptor and dialect from a sample of *content*.
 
@@ -96,10 +110,20 @@ def infer_table_schema(
         {"name": name, "type": _infer_column_type(read_result.dataframe[name].tolist())}
         for name in read_result.column_names
     ]
+    descriptor = {"fields": fields}
+    serialized_size = len(
+        json.dumps(descriptor, separators=(",", ":")).encode("utf-8"),
+    )
+    if serialized_size > max_schema_bytes:
+        msg = (
+            f"Inferred schema is {serialized_size} bytes, over the "
+            f"{max_schema_bytes}-byte limit."
+        )
+        raise InferenceError(msg, code=CODE_INFERRED_SCHEMA_TOO_LARGE)
 
     resolved_dialect = TabularDialect(
         delimiter=read_result.preflight.delimiter,
         has_header=read_result.preflight.has_header,
         encoding=read_result.preflight.encoding,
     )
-    return InferredSchema(descriptor={"fields": fields}, dialect=resolved_dialect)
+    return InferredSchema(descriptor=descriptor, dialect=resolved_dialect)

--- a/validibot/validations/validators/tabular/preflight.py
+++ b/validibot/validations/validators/tabular/preflight.py
@@ -35,6 +35,7 @@ CODE_ENCODING_ERROR = "tabular.encoding_error"
 CODE_EMPTY_FILE = "tabular.empty_file"
 CODE_TOO_MANY_COLUMNS = "tabular.too_many_columns"
 CODE_DIALECT_MISMATCH = "tabular.dialect_mismatch"
+CODE_DIALECT_UNDETERMINED = "tabular.dialect_undetermined"
 
 # Sniff the dialect from at most this many decoded characters. The header
 # and a few rows are plenty to detect a delimiter; sniffing the whole file
@@ -45,6 +46,17 @@ _SNIFF_SAMPLE_CHARS = 65536
 # avoids the sniffer guessing an exotic separator from incidental
 # punctuation in the data.
 _SNIFF_DELIMITERS = ",\t;|"
+
+# When ``csv.Sniffer`` cannot decide, compare a small number of logical
+# records with each supported delimiter. A real delimiter produces the same
+# multi-column width for every well-formed record; punctuation inside values
+# generally does not. Keeping this fallback bounded preserves PREFLIGHT's
+# cheap-cost contract.
+_SNIFF_FALLBACK_RECORDS = 25
+
+# Column names are carried through Django form fields and the portable Table
+# Schema descriptor. This matches the editor's existing column-name limit.
+MAX_HEADER_NAME_CHARS = 255
 
 # Default delimiter when nothing is declared and sniffing is inconclusive
 # (e.g. a single-column file has no delimiter to detect). Comma is the
@@ -81,6 +93,11 @@ class TabularLimits:
     max_bytes: int = 50 * 1024 * 1024  # 50 MB
     max_rows: int = 1_000_000
     max_columns: int = 1024
+    max_header_name_chars: int = MAX_HEADER_NAME_CHARS
+    # Header names become schema fields and UI form values. Bounding each name
+    # prevents a small file with one enormous header cell from producing an
+    # unwieldy descriptor or response while leaving ample room for URI-shaped
+    # scientific vocabulary terms.
     # Wall-clock budget for the *native* validation pass (per submission). The
     # per-row CEL lane already caps its loop; native validation needs the same
     # because an author-supplied regex ``pattern`` runs against every cell, and
@@ -150,30 +167,94 @@ def _decode(content: bytes, encoding: str) -> str:
         raise PreflightError(msg, code=CODE_ENCODING_ERROR) from exc
 
 
-def _sniff_delimiter(sample: str) -> str | None:
+def _consistent_delimiter_candidates(
+    sample: str,
+    *,
+    quotechar: str,
+) -> list[str]:
+    """Return delimiters that produce one consistent multi-column width.
+
+    Every candidate is parsed with the standard CSV reader so quoted
+    punctuation is ignored. A candidate only qualifies when all sampled
+    logical records have the same width greater than one. The caller uses this
+    both as a fallback when :class:`csv.Sniffer` fails and as an ambiguity check
+    when the heuristic sniffer chooses one of several plausible delimiters.
+    """
+    candidates: list[str] = []
+    for delimiter in _SNIFF_DELIMITERS:
+        widths: list[int] = []
+        try:
+            reader = csv.reader(
+                io.StringIO(sample),
+                delimiter=delimiter,
+                quotechar=quotechar,
+                strict=True,
+            )
+            for record in reader:
+                if not record or (len(record) == 1 and record[0] == ""):
+                    continue
+                widths.append(len(record))
+                if len(widths) >= _SNIFF_FALLBACK_RECORDS:
+                    break
+        except csv.Error:
+            continue
+        if widths and widths[0] > 1 and len(set(widths)) == 1:
+            candidates.append(delimiter)
+    return candidates
+
+
+def _sniff_delimiter(sample: str, *, quotechar: str) -> str | None:
     """Best-effort delimiter detection over a bounded text sample.
 
-    Returns ``None`` when the sniffer cannot decide (e.g. a single-column
-    file with no delimiter at all) so the caller can fall back to a
-    sensible default rather than propagating a sniff error.
+    Returns ``None`` when neither the standard sniffer nor the conservative
+    consistent-width fallback can decide. The caller distinguishes a genuine
+    single-column file from ambiguous delimiter-bearing content.
     """
     try:
-        dialect = csv.Sniffer().sniff(sample, delimiters=_SNIFF_DELIMITERS)
+        sniffed = (
+            csv.Sniffer()
+            .sniff(
+                sample,
+                delimiters=_SNIFF_DELIMITERS,
+            )
+            .delimiter
+        )
     except csv.Error:
+        sniffed = None
+
+    candidates = _consistent_delimiter_candidates(sample, quotechar=quotechar)
+    if len(candidates) == 1:
+        return candidates[0]
+    if len(candidates) > 1:
         return None
-    return dialect.delimiter
+    return sniffed
 
 
-def _resolve_delimiter(declared: str | None, sample: str) -> str:
+def _resolve_delimiter(
+    declared: str | None,
+    sample: str,
+    *,
+    quotechar: str,
+) -> str:
     """Apply the delimiter decision: declared overrides, mismatch fails.
 
     - If a delimiter is declared, it is authoritative; but if a sniff also
       produces a *different* delimiter, the disagreement is a clean failure
       (an honest "you said comma, this looks tab-delimited" beats a guess).
-    - If nothing is declared, use the sniffed delimiter; if sniffing is
-      inconclusive, fall back to the default (comma).
+    - If nothing is declared, use the sniffed delimiter. Ambiguous content
+      fails with guidance; content with no delimiter is a valid single-column
+      file and uses the default comma dialect internally.
     """
-    sniffed = _sniff_delimiter(sample)
+    sniffed = _sniff_delimiter(sample, quotechar=quotechar)
+    visible_candidates = [
+        delimiter for delimiter in _SNIFF_DELIMITERS if delimiter in sample
+    ]
+    # If only one supported delimiter character occurs, it remains the only
+    # defensible dialect even when ragged rows make consistency-based sniffing
+    # fail. Resolve it here and let READ produce the more accurate strict parse
+    # error for the malformed body.
+    if sniffed is None and len(visible_candidates) == 1:
+        sniffed = visible_candidates[0]
     if declared is not None:
         if sniffed is not None and sniffed != declared:
             msg = (
@@ -182,7 +263,15 @@ def _resolve_delimiter(declared: str | None, sample: str) -> str:
             )
             raise PreflightError(msg, code=CODE_DIALECT_MISMATCH)
         return declared
-    return sniffed if sniffed is not None else _DEFAULT_DELIMITER
+    if sniffed is not None:
+        return sniffed
+    if visible_candidates:
+        msg = (
+            "Could not determine the file delimiter unambiguously. "
+            "Select the delimiter explicitly and try again."
+        )
+        raise PreflightError(msg, code=CODE_DIALECT_UNDETERMINED)
+    return _DEFAULT_DELIMITER
 
 
 def _read_first_record(text: str, delimiter: str, quotechar: str) -> list[str]:
@@ -232,7 +321,11 @@ def run_preflight(
         raise PreflightError("File has no content.", code=CODE_EMPTY_FILE)
 
     sample = text[:_SNIFF_SAMPLE_CHARS]
-    delimiter = _resolve_delimiter(dialect.delimiter, sample)
+    delimiter = _resolve_delimiter(
+        dialect.delimiter,
+        sample,
+        quotechar=dialect.quotechar,
+    )
 
     first_record = _read_first_record(text, delimiter, dialect.quotechar)
     field_count = len(first_record)

--- a/validibot/validations/validators/tabular/readers/csv.py
+++ b/validibot/validations/validators/tabular/readers/csv.py
@@ -32,6 +32,7 @@ CODE_TOO_MANY_ROWS = "tabular.too_many_rows"
 CODE_DUPLICATE_HEADER = "tabular.duplicate_header"
 CODE_BLANK_HEADER = "tabular.blank_header"
 CODE_HEADER_CASE_COLLISION = "tabular.header_case_collision"
+CODE_HEADER_NAME_TOO_LONG = "tabular.header_name_too_long"
 CODE_COLUMN_COUNT_MISMATCH = "tabular.column_count_mismatch"
 
 
@@ -61,7 +62,11 @@ class ReadResult:
     preflight: PreflightResult
 
 
-def _canonical_header_names(raw_names: list[str]) -> list[str]:
+def _canonical_header_names(
+    raw_names: list[str],
+    *,
+    max_name_chars: int,
+) -> list[str]:
     """Validate and canonicalise header names; fail on unsafe headers.
 
     ``row.*`` keys come from these names, so the header must be nailed down
@@ -82,6 +87,14 @@ def _canonical_header_names(raw_names: list[str]) -> list[str]:
     if blanks:
         msg = f"Header has blank/empty column name(s) at position(s): {blanks}."
         raise ParseError(msg, code=CODE_BLANK_HEADER)
+
+    oversized = [i + 1 for i, name in enumerate(names) if len(name) > max_name_chars]
+    if oversized:
+        msg = (
+            f"Header has column name(s) over the {max_name_chars}-character "
+            f"limit at position(s): {oversized}."
+        )
+        raise ParseError(msg, code=CODE_HEADER_NAME_TOO_LONG)
 
     # Track first occurrence by casefolded key so we can tell an exact
     # duplicate (same bytes) apart from a case-only collision.
@@ -107,6 +120,7 @@ def _resolve_logical_names(
     column_count: int,
     header_names: list[str] | None,
     declared_columns: list[str] | None,
+    max_header_name_chars: int,
 ) -> list[str]:
     """Resolve the one canonical logical name for each column position.
 
@@ -121,7 +135,10 @@ def _resolve_logical_names(
     is declared — there is no second naming layer.
     """
     if header_names is not None:
-        return _canonical_header_names(header_names)
+        return _canonical_header_names(
+            header_names,
+            max_name_chars=max_header_name_chars,
+        )
 
     declared = declared_columns or []
     return [
@@ -168,7 +185,10 @@ def read_csv(
     # record — not pandas' auto-mangled columns — so a duplicate header
     # fails cleanly instead of being silently renamed to ``value.1``.
     if preflight.header_names is not None:
-        canonical_header = _canonical_header_names(preflight.header_names)
+        canonical_header = _canonical_header_names(
+            preflight.header_names,
+            max_name_chars=limits.max_header_name_chars,
+        )
     else:
         canonical_header = None
 
@@ -215,6 +235,7 @@ def read_csv(
         column_count=column_count,
         header_names=canonical_header,
         declared_columns=declared_columns,
+        max_header_name_chars=limits.max_header_name_chars,
     )
     frame.columns = pd.Index(logical_names)
 

--- a/validibot/validations/validators/tabular/schema.py
+++ b/validibot/validations/validators/tabular/schema.py
@@ -23,6 +23,8 @@ from django.utils.html import format_html
 from django.utils.html import format_html_join
 from django.utils.translation import gettext_lazy as _
 
+from validibot.validations.validators.tabular.preflight import MAX_HEADER_NAME_CHARS
+
 # The field types V1 understands. Anything else is treated as ``string``.
 SUPPORTED_TYPES: frozenset[str] = frozenset(
     {"string", "number", "integer", "boolean", "date", "datetime"},
@@ -433,10 +435,11 @@ def _validate_field_names(names: list[str]) -> None:
     ``AttributeError`` mid-validation. Catching it here turns a crash into a
     clean configuration error.
 
-    Three rules, all raising ``ValueError`` (an unusable *value*, not a wrong
+    Four rules, all raising ``ValueError`` (an unusable *value*, not a wrong
     *type*):
 
     - blank-after-trim → a column with no usable name can't be addressed;
+    - overlong → a hostile name cannot inflate forms and generated schemas;
     - exact duplicate → ``row.value`` / ``frame[name]`` would be ambiguous;
     - case-only collision → Table Schema treats names as not-case-sensitive for
       uniqueness, so ``Lat`` vs ``lat`` is a collision, not two columns.
@@ -444,6 +447,16 @@ def _validate_field_names(names: list[str]) -> None:
     blanks = [i + 1 for i, name in enumerate(names) if name.strip() == ""]
     if blanks:
         msg = f"Table Schema has blank field name(s) at position(s): {blanks}."
+        raise ValueError(msg)
+
+    oversized = [
+        i + 1 for i, name in enumerate(names) if len(name) > MAX_HEADER_NAME_CHARS
+    ]
+    if oversized:
+        msg = (
+            f"Table Schema has field name(s) over the "
+            f"{MAX_HEADER_NAME_CHARS}-character limit at position(s): {oversized}."
+        )
         raise ValueError(msg)
 
     # Track first occurrence by trimmed+casefolded key so an exact duplicate

--- a/validibot/workflows/forms.py
+++ b/validibot/workflows/forms.py
@@ -3448,6 +3448,10 @@ TABULAR_DELIMITER_CHOICES = [
 ]
 # Sample uploads for inference are small by nature; cap to keep it cheap.
 TABULAR_SAMPLE_MAX_BYTES = 5 * 1024 * 1024  # 5 MB
+# The multipart request also carries the current editor state. Check its total
+# size before Django parses uploaded files, leaving headroom above the sample
+# cap without accepting an unbounded request body at this endpoint.
+TABULAR_INFER_REQUEST_MAX_BYTES = 10 * 1024 * 1024  # 10 MB
 TABULAR_SCHEMA_MAX_BYTES = 2 * 1024 * 1024  # 2 MB
 TABULAR_COLUMN_FORMSET_PREFIX = "columns"
 TABULAR_TYPE_CHOICES = [
@@ -3857,7 +3861,7 @@ class TabularStepConfigForm(BaseStepConfigForm):
 
     Configures the file dialect (delimiter / header) and the column
     schema. The schema can be provided two ways: paste a Frictionless Table
-    Schema descriptor, or upload a sample CSV to *infer* one (the inferred
+    Schema descriptor, or upload delimited text to *infer* one (the inferred
     descriptor is stored and shown for the author to tighten next time). The
     descriptor is written to ``ruleset.rules_text`` and the dialect to
     ``ruleset.metadata`` by ``build_tabular_config``.
@@ -3904,15 +3908,16 @@ class TabularStepConfigForm(BaseStepConfigForm):
         ),
     )
     sample_file = forms.FileField(
-        label=_("Infer from a sample file"),
+        label=_("Infer from a delimited text sample"),
         required=False,
         help_text=_(
-            "Upload a small sample CSV to infer column names and types.",
+            "Upload a small comma-, tab-, semicolon-, or pipe-delimited text "
+            "file to infer column names and types. The filename extension "
+            "does not matter.",
         ),
         widget=forms.ClearableFileInput(
             attrs={
                 "class": "form-control",
-                "accept": ".csv,.tsv,text/csv,text/tab-separated-values",
             },
         ),
     )

--- a/validibot/workflows/tests/test_tabular_step_config.py
+++ b/validibot/workflows/tests/test_tabular_step_config.py
@@ -40,6 +40,8 @@ from validibot.validations.tests.factories import RulesetAssertionFactory
 from validibot.validations.tests.factories import RulesetFactory
 from validibot.validations.tests.factories import ValidatorFactory
 from validibot.validations.validators.tabular.schema import parse_table_schema
+from validibot.workflows.forms import TABULAR_INFER_REQUEST_MAX_BYTES
+from validibot.workflows.forms import TABULAR_SAMPLE_MAX_BYTES
 from validibot.workflows.forms import TabularStepConfigForm
 from validibot.workflows.tests.factories import WorkflowFactory
 from validibot.workflows.tests.factories import WorkflowStepFactory
@@ -148,13 +150,16 @@ class TabularStepConfigFormTests(SimpleTestCase):
         self.assertIn("table_schema", form.errors)
 
     def test_sample_upload_infers_descriptor(self):
-        """Uploading a sample CSV infers a descriptor (tagged ``infer``), typed
-        from the sample's values — the no-coding setup path.
+        """A tab-delimited ``.txt`` sample infers a typed descriptor.
+
+        GBIF and OBIS commonly package Darwin Core tables this way. Inference
+        is content-based, so neither a ``.csv`` suffix nor ``text/csv`` MIME
+        metadata is required for the no-coding setup path.
         """
         sample = SimpleUploadedFile(
-            "sample.csv",
-            b"lat,lon\n10,20\n-5,30\n",
-            content_type="text/csv",
+            "occurrence.txt",
+            b"lat\tlon\n10\t20\n-5\t30\n",
+            content_type="text/plain",
         )
         form = TabularStepConfigForm(
             data={"name": "x", "encoding": "utf-8", "has_header": "on"},
@@ -602,6 +607,9 @@ class TabularStepSettingsViewTests(TestCase):
         # target, which is stable even if the button labels change).
         self.assertContains(response, 'data-bs-target="#tabularInferModal"')
         self.assertContains(response, 'data-bs-target="#tabularImportModal"')
+        self.assertContains(response, "Delimited text sample")
+        self.assertContains(response, "filename extension does not matter")
+        self.assertNotContains(response, 'accept=".csv')
         self.assertContains(response, "data-tabular-column-editor")
         self.assertNotContains(response, 'id="tabular-assertions-heading"')
         self.assertContains(response, "Required when another column exists")
@@ -1048,12 +1056,13 @@ class TabularStepSettingsViewTests(TestCase):
         self.assertNotContains(response, 'value="unsaved_column"')
 
     def test_infer_endpoint_previews_columns_and_resolves_dialect(self):
-        """Inference previews typed rows and updates dialect controls.
+        """A tab-delimited ``.txt`` previews columns and resolves its dialect.
 
         The sample upload cannot be replayed after the response, so inference
         stores the proposed descriptor in the preview. Applying that descriptor
-        is a separate request and the resolved dialect is still returned
-        through HTMx out-of-band swaps.
+        is a separate request and the resolved tab dialect is still returned
+        through HTMx out-of-band swaps. The filename and generic text MIME type
+        deliberately play no part in parsing.
         """
         workflow, step = self._tabular_workflow_and_step()
         _login_as_author(self.client, workflow)
@@ -1062,9 +1071,9 @@ class TabularStepSettingsViewTests(TestCase):
             kwargs={"pk": workflow.pk, "step_id": step.pk},
         )
         sample = SimpleUploadedFile(
-            "sample.csv",
-            b"site_id,reading\nA-1,12.5\nA-2,13.75\n",
-            content_type="text/csv",
+            "occurrence.txt",
+            b"site_id\treading\nA-1\t12.5\nA-2\t13.75\n",
+            content_type="text/plain",
         )
 
         response = self.client.post(
@@ -1087,6 +1096,7 @@ class TabularStepSettingsViewTests(TestCase):
         self.assertContains(response, "site_id")  # carried in pending_schema
         self.assertNotContains(response, 'value="site_id"')
         self.assertContains(response, 'hx-swap-oob="outerHTML"')
+        self.assertContains(response, 'value="\t" selected')
 
         apply_url = reverse(
             "workflows:workflow_tabular_schema_apply_existing",
@@ -1115,6 +1125,119 @@ class TabularStepSettingsViewTests(TestCase):
         self.assertContains(applied, 'value="site_id"')
         self.assertContains(applied, 'value="reading"')
         self.assertContains(applied, 'value="number" selected')
+
+    def test_infer_endpoint_rejects_binary_content_cleanly(self):
+        """Binary bytes disguised with a text extension remain inert.
+
+        The endpoint performs strict UTF-8 decoding and returns an author-facing
+        error; it does not execute, persist, or attempt to repair the payload.
+        """
+        workflow, step = self._tabular_workflow_and_step()
+        _login_as_author(self.client, workflow)
+        url = reverse(
+            "workflows:workflow_tabular_schema_infer_existing",
+            kwargs={"pk": workflow.pk, "step_id": step.pk},
+        )
+        sample = SimpleUploadedFile(
+            "occurrence.txt",
+            b"id\tvalue\n1\t\xff\n",
+            content_type="text/plain",
+        )
+
+        response = self.client.post(
+            url,
+            {"sample_file": sample, "delimiter": "", "has_header": "on"},
+            headers={"hx-request": "true"},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Could not decode the file")
+        self.assertEqual(
+            response.headers.get("HX-Retarget"),
+            "#tabular-infer-input-error",
+        )
+
+    def test_infer_endpoint_rejects_oversized_sample(self):
+        """A sample over 5 MB is rejected before schema inference.
+
+        This bounds decode and dataframe work even when the overall multipart
+        request remains under its separate request-size ceiling.
+        """
+        workflow, step = self._tabular_workflow_and_step()
+        _login_as_author(self.client, workflow)
+        url = reverse(
+            "workflows:workflow_tabular_schema_infer_existing",
+            kwargs={"pk": workflow.pk, "step_id": step.pk},
+        )
+        sample = SimpleUploadedFile(
+            "large.data",
+            b"x" * (TABULAR_SAMPLE_MAX_BYTES + 1),
+            content_type="application/octet-stream",
+        )
+
+        response = self.client.post(
+            url,
+            {"sample_file": sample},
+            headers={"hx-request": "true"},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Sample files must be 5 MB or smaller")
+
+    def test_infer_endpoint_rejects_oversized_request_before_file_parsing(self):
+        """The complete multipart request is bounded before ``request.FILES``.
+
+        File-size checks run after multipart parsing, so the Content-Length
+        guard prevents a large request from first consuming temporary storage
+        or memory merely to discover that its sample is too large.
+        """
+        workflow, step = self._tabular_workflow_and_step()
+        _login_as_author(self.client, workflow)
+        url = reverse(
+            "workflows:workflow_tabular_schema_infer_existing",
+            kwargs={"pk": workflow.pk, "step_id": step.pk},
+        )
+
+        response = self.client.generic(
+            "POST",
+            url,
+            b"",
+            content_type="multipart/form-data; boundary=validibot",
+            CONTENT_LENGTH=str(TABULAR_INFER_REQUEST_MAX_BYTES + 1),
+            HTTP_HX_REQUEST="true",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Inference requests must be 10 MB or smaller")
+
+    def test_inferred_hostile_header_is_html_escaped(self):
+        """An HTML-shaped header is data, never executable review markup.
+
+        Header names are carried in a hidden JSON form field, so this pins
+        Django's escaping at the HTTP boundary where an XSS regression would
+        otherwise occur.
+        """
+        workflow, step = self._tabular_workflow_and_step()
+        _login_as_author(self.client, workflow)
+        url = reverse(
+            "workflows:workflow_tabular_schema_infer_existing",
+            kwargs={"pk": workflow.pk, "step_id": step.pk},
+        )
+        sample = SimpleUploadedFile(
+            "hostile.anything",
+            b"<script>alert(1)</script>\tvalue\nplain\t1\n",
+            content_type="text/plain",
+        )
+
+        response = self.client.post(
+            url,
+            {"sample_file": sample, "delimiter": "", "has_header": "on"},
+            headers={"hx-request": "true"},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(response, "<script>alert(1)</script>")
+        self.assertContains(response, "&lt;script&gt;alert(1)&lt;/script&gt;")
 
     def test_import_preview_reports_unsupported_features(self):
         """Import compatibility warnings are visible before replacement.

--- a/validibot/workflows/views/steps.py
+++ b/validibot/workflows/views/steps.py
@@ -48,6 +48,7 @@ from validibot.validations.models import StepIODefinition
 from validibot.validations.models import Validator
 from validibot.validations.validators.base.config import get_config
 from validibot.workflows.forms import TABULAR_COLUMN_FORMSET_PREFIX
+from validibot.workflows.forms import TABULAR_INFER_REQUEST_MAX_BYTES
 from validibot.workflows.forms import TABULAR_SAMPLE_MAX_BYTES
 from validibot.workflows.forms import TABULAR_SCHEMA_MAX_BYTES
 from validibot.workflows.forms import SignalBindingEditForm
@@ -939,7 +940,13 @@ class TabularSchemaImportView(TabularSettingsEndpointMixin, View):
 
 
 class TabularSchemaInferView(TabularSettingsEndpointMixin, View):
-    """Infer a starting descriptor and preview it before replacement."""
+    """Infer a starting descriptor from bounded delimited text.
+
+    The endpoint checks the complete multipart request size before touching
+    ``request.FILES``. This complements the uploaded-file size check: Django
+    otherwise has to parse and spool an arbitrarily large request before the
+    application can inspect ``UploadedFile.size``.
+    """
 
     #: Input-screen error slot for this modal (HX-Retarget target on failure).
     ERROR_TARGET = "#tabular-infer-input-error"
@@ -949,10 +956,21 @@ class TabularSchemaInferView(TabularSettingsEndpointMixin, View):
         from validibot.validations.validators.tabular.preflight import TabularDialect
         from validibot.validations.validators.tabular.preflight import TabularReadError
 
+        raw_content_length = request.headers.get("content-length", "")
+        try:
+            content_length = int(raw_content_length)
+        except (TypeError, ValueError):
+            content_length = 0
+        if content_length > TABULAR_INFER_REQUEST_MAX_BYTES:
+            return self._render_input_error(
+                _("Inference requests must be 10 MB or smaller."),
+                self.ERROR_TARGET,
+            )
+
         sample = request.FILES.get("sample_file")
         if sample is None:
             return self._render_input_error(
-                _("Choose a sample CSV first."),
+                _("Choose a delimited text sample first."),
                 self.ERROR_TARGET,
             )
         if sample.size > TABULAR_SAMPLE_MAX_BYTES:


### PR DESCRIPTION
## Summary

- accept delimited-text samples regardless of filename extension or MIME type, including Darwin Core .txt files
- detect comma, tab, semicolon, and pipe delimiters from content and require an explicit choice when detection is ambiguous
- add request, sample, header-name, and generated-schema bounds plus strict binary and hostile-header handling
- update the Tabular Validator UI and documentation

## Verification

- 174 Tabular regression tests passed, plus 11 subtests
- repository Ruff and commit hooks passed
- Django template lint passed
- documentation build passed

Fixes #222