### PR TITLE
Preserve retention truth when storage deletion fails

### DIFF
--- a/validibot/submissions/models.py
+++ b/validibot/submissions/models.py
@@ -586,7 +586,24 @@ class Submission(TimeStampedModel):
         if self.content_purged_at:
             return  # Already purged (idempotent)
 
-        # Delete file from storage
+        # Delete every run bundle before the original input. If a bundle delete
+        # fails, keeping the input and database fields intact gives the retry a
+        # coherent source record instead of leaving an unpurged submission that
+        # already lost part of its content. External deletes are idempotent, so
+        # a retry can safely revisit bundles removed before a later failure.
+        for run in self.runs.all():
+            try:
+                _delete_run_files(run)
+            except Exception:
+                logger.exception(
+                    "Failed to delete run files",
+                    extra={"submission_id": str(self.id), "run_id": str(run.id)},
+                )
+                raise
+
+        # Delete the original input only after every related run bundle is
+        # confirmed absent. A failed input deletion likewise prevents the
+        # database from claiming the submission was purged.
         if self.input_file:
             try:
                 self.input_file.delete(save=False)
@@ -596,17 +613,6 @@ class Submission(TimeStampedModel):
                     extra={"id": str(self.id)},
                 )
                 raise
-
-        # Delete run files for all validation runs
-        for run in self.runs.all():
-            try:
-                _delete_run_files(run)
-            except Exception:
-                logger.exception(
-                    "Failed to delete run files",
-                    extra={"submission_id": str(self.id), "run_id": str(run.id)},
-                )
-                # Continue with other runs - don't fail entire purge
 
         # Clear content
         self.content = ""

--- a/validibot/submissions/tests/test_retention.py
+++ b/validibot/submissions/tests/test_retention.py
@@ -14,6 +14,7 @@ from io import StringIO
 from unittest.mock import patch
 
 import pytest
+from django.core.files.base import ContentFile
 from django.core.management import call_command
 from django.test import override_settings
 from django.utils import timezone
@@ -108,6 +109,41 @@ class TestSubmissionPurgeContent:
 
         # Should have been called for the related run
         mock_delete.assert_called_once_with(run)
+
+    @patch("validibot.submissions.models._delete_run_files")
+    def test_purge_content_preserves_input_when_run_deletion_fails(
+        self,
+        mock_delete,
+        tmp_path,
+    ):
+        """A failed run-bundle delete must leave the submission retryable.
+
+        Retention truth depends on keeping both the database identity and any
+        not-yet-deleted input bytes until every required run bundle is gone.
+        Deleting the input first would leave an unpurged record whose content
+        could no longer be read or retried coherently.
+        """
+        mock_delete.side_effect = OSError("object storage unavailable")
+
+        with override_settings(MEDIA_ROOT=str(tmp_path)):
+            submission = SubmissionFactory(content='{"test": "data"}')
+            submission.input_file.save(
+                "submission.json",
+                ContentFile(b'{"test": "data"}'),
+                save=False,
+            )
+            submission.content = ""
+            submission.save(update_fields=["content", "input_file"])
+            ValidationRunFactory(submission=submission)
+            original_file_name = submission.input_file.name
+
+            with pytest.raises(OSError, match="object storage unavailable"):
+                submission.purge_content()
+
+            submission.refresh_from_db()
+            assert submission.content_purged_at is None
+            assert submission.input_file.name == original_file_name
+            assert submission.input_file.storage.exists(original_file_name)
 
     @override_settings(GCS_VALIDATION_BUCKET="test-validation-bucket")
     @patch("validibot.validations.services.cloud_run.gcs_client.delete_prefix")

--- a/validibot/validations/management/commands/purge_expired_outputs.py
+++ b/validibot/validations/management/commands/purge_expired_outputs.py
@@ -194,6 +194,11 @@ class Command(BaseCommand):
                     "Failed to delete artifact file",
                     extra={"run_id": run_id, "artifact_id": artifact.id},
                 )
+                # The artifact row is the durable identity required to retry
+                # this external delete. Propagate the failure so the enclosing
+                # transaction restores findings/artifact rows and never stamps
+                # output_purged_at while bytes may remain.
+                raise
             artifact.delete()
 
         if artifacts:

--- a/validibot/validations/tests/test_purge_expired_outputs.py
+++ b/validibot/validations/tests/test_purge_expired_outputs.py
@@ -1,0 +1,77 @@
+"""Regression tests for truthful validation-output retention.
+
+Output purge spans PostgreSQL and external storage without a shared
+transaction. These tests pin the critical rule that a storage failure must
+leave database identities and purge timestamps available for a later retry;
+otherwise Validibot could claim deletion while bytes remain, or discard the
+only record that tells operators what still needs deleting.
+"""
+
+from datetime import timedelta
+from io import StringIO
+from unittest.mock import patch
+
+import pytest
+from django.core.management import call_command
+from django.utils import timezone
+
+from validibot.submissions.constants import OutputRetention
+from validibot.validations.models import Artifact
+from validibot.validations.models import ValidationFinding
+from validibot.validations.tests.factories import ArtifactFactory
+from validibot.validations.tests.factories import ValidationFindingFactory
+from validibot.validations.tests.factories import ValidationRunFactory
+from validibot.validations.tests.factories import ValidationStepRunFactory
+
+
+@pytest.mark.django_db
+class TestPurgeExpiredOutputFailures:
+    """Prove failed external deletion cannot become a successful purge."""
+
+    def test_artifact_delete_failure_preserves_retry_identity(self):
+        """An undeleted artifact must retain its row and unpurged run state.
+
+        Findings are deleted before artifacts in the purge transaction, so
+        retaining the finding also proves the database work rolled back rather
+        than partially committing around the storage failure.
+        """
+        run = ValidationRunFactory(
+            output_retention_policy=OutputRetention.STORE_7_DAYS,
+            output_expires_at=timezone.now() - timedelta(minutes=1),
+        )
+        step_run = ValidationStepRunFactory(validation_run=run)
+        finding = ValidationFindingFactory(
+            validation_run=run,
+            validation_step_run=step_run,
+        )
+
+        artifact_file_name = "artifacts/test/report.txt"
+        artifact = ArtifactFactory(
+            validation_run=run,
+            org=run.org,
+            file=artifact_file_name,
+        )
+
+        stdout = StringIO()
+        stderr = StringIO()
+        with patch(
+            "django.db.models.fields.files.FieldFile.delete",
+            side_effect=OSError("artifact storage unavailable"),
+        ):
+            call_command(
+                "purge_expired_outputs",
+                "--batch-size=10",
+                "--max-batches=1",
+                stdout=stdout,
+                stderr=stderr,
+            )
+
+        run.refresh_from_db()
+        assert run.output_purged_at is None
+        assert run.output_expires_at is not None
+        assert Artifact.objects.filter(pk=artifact.pk).exists()
+        assert ValidationFinding.objects.filter(pk=finding.pk).exists()
+        artifact.refresh_from_db()
+        assert artifact.file.name == artifact_file_name
+        assert "Failed to purge outputs" in stdout.getvalue()
+        assert "1 run(s) failed to purge" in stderr.getvalue()


### PR DESCRIPTION
## Summary

- delete related run bundles before removing the original submission input
- propagate run-bundle deletion failures so submission records remain unpurged and retryable
- propagate artifact deletion failures so the enclosing transaction preserves findings, artifact identity, and the unpurged run state
- add documented regression coverage for both failure paths

## Why

Database state must not claim that retained data was purged when an external storage operation failed. Durable-deletion and lease-kernel work will follow separately.

## Verification

- focused retention suite: 38 passed
- full Validibot suite: 4,445 passed, 32 skipped, 68 subtests passed
- Ruff check and format checks passed
- pre-commit hooks passed