### PR TITLE
Harden provider execution failure, cancellation, and timeout handling

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -967,6 +967,10 @@ else:
 #
 # See validibot/validations/services/runners/ for implementation details.
 VALIDATOR_RUNNER = env("VALIDATOR_RUNNER", default="docker")
+# One outer wall-clock budget shared by the runner and the stuck-run watchdog.
+# Provider deployment recipes use the same environment variable and default,
+# so the watchdog never declares timeout before the configured runtime does.
+VALIDATOR_TIMEOUT_SECONDS = env.int("VALIDATOR_TIMEOUT_SECONDS", default=3600)
 VALIDATOR_RUNNER_OPTIONS = {
     "memory_limit": env("VALIDATOR_MEMORY_LIMIT", default="4g"),
     "cpu_limit": env("VALIDATOR_CPU_LIMIT", default="2.0"),
@@ -976,6 +980,7 @@ VALIDATOR_RUNNER_OPTIONS = {
     "storage_volume": env("VALIDATOR_STORAGE_VOLUME", default=None),
     # Mount path for storage volume inside validator containers
     "storage_mount_path": env("VALIDATOR_STORAGE_MOUNT_PATH", default="/app/storage"),
+    "timeout_seconds": VALIDATOR_TIMEOUT_SECONDS,
 }
 
 # Validator backend trust-tier hardening overrides (Trust ADR

--- a/config/settings/local.py
+++ b/config/settings/local.py
@@ -187,7 +187,7 @@ VALIDATOR_RUNNER_OPTIONS = {
     "memory_limit": env("VALIDATOR_MEMORY_LIMIT", default="4g"),
     "cpu_limit": env("VALIDATOR_CPU_LIMIT", default="2.0"),
     "network": env("VALIDATOR_NETWORK", default=None),
-    "timeout_seconds": env.int("VALIDATOR_TIMEOUT_SECONDS", default=3600),
+    "timeout_seconds": VALIDATOR_TIMEOUT_SECONDS,  # noqa: F405
     # Named volume for storage (validator containers mount this)
     "storage_volume": env("VALIDATOR_STORAGE_VOLUME", default=None),
     # Mount path for storage volume inside validator containers

--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -472,7 +472,7 @@ else:  # self_hosted (DeploymentTarget.SELF_HOSTED — single-VM Docker Compose)
         "memory_limit": env("VALIDATOR_MEMORY_LIMIT", default="4g"),
         "cpu_limit": env("VALIDATOR_CPU_LIMIT", default="2.0"),
         "network": env("VALIDATOR_NETWORK", default=None),
-        "timeout_seconds": env.int("VALIDATOR_TIMEOUT_SECONDS", default=3600),
+        "timeout_seconds": VALIDATOR_TIMEOUT_SECONDS,  # noqa: F405
     }
 
     # Container image configuration for advanced validators

--- a/docs/dev_docs/how-to/configure-scheduled-tasks.md
+++ b/docs/dev_docs/how-to/configure-scheduled-tasks.md
@@ -51,7 +51,7 @@ Current entries:
 | `purge_expired_submissions` | Hourly | Remove expired user submission content |
 | `purge_expired_outputs` | Hourly | Remove expired validation outputs |
 | `process_purge_retries` | Every 5 minutes | Retry failed purge operations |
-| `cleanup_stuck_runs` | Every 10 minutes | Mark hung runs as failed |
+| `cleanup_stuck_runs` | Every 10 minutes | Reconcile or time out and cancel hung runs |
 | `cleanup_orphaned_containers` | Every 10 minutes | Remove orphaned Docker containers (Docker Compose only) |
 | `cleanup_idempotency_keys` | Daily at 3 AM | Remove expired idempotency keys |
 | `cleanup_callback_receipts` | Weekly (Sunday 4 AM) | Clean old callback receipts |

--- a/docs/dev_docs/overview/execution_backends.md
+++ b/docs/dev_docs/overview/execution_backends.md
@@ -416,7 +416,8 @@ If a Cloud Run Job completes but its callback never reaches Django (network fail
 2. For GCP runs, checks `step_run.output` for `execution_name` metadata
 3. Queries Cloud Run Jobs API via `GCPExecutionBackend.check_status()`
 4. Based on result:
-   - **Still running**: Skips the run (legitimately in progress)
+   - **Still running after the configured outer deadline**: Marks the run
+     `TIMED_OUT`, then requests provider cancellation
    - **Succeeded**: Constructs a synthetic callback and processes through `ValidationCallbackService` (reuses existing idempotency, finding persistence, assertion evaluation)
    - **Failed**: Marks the run as `FAILED` with the Cloud Run error message
    - **API error**: Falls through to simple `TIMED_OUT` marking
@@ -425,7 +426,12 @@ This reconciliation runs automatically when `cleanup_stuck_runs` is scheduled (t
 
 ### Stuck Run Timeout (All Backends)
 
-For runs where reconciliation is not possible (non-GCP, no execution metadata, API errors), the command marks them as `TIMED_OUT` after the configured threshold (default: 30 minutes).
+For runs where reconciliation is not possible (non-GCP, no execution metadata,
+API errors), the command marks them as `TIMED_OUT` after the configured
+`VALIDATOR_TIMEOUT_SECONDS` threshold (default: 3600 seconds / 60 minutes). The
+same setting configures local container runtime and the GCP validator Job deploy
+recipe. `--timeout-minutes` remains available as an explicit operational
+override.
 
 ```bash
 # Manual invocation

--- a/docs/dev_docs/validator_jobs_cloud_run.md
+++ b/docs/dev_docs/validator_jobs_cloud_run.md
@@ -236,12 +236,14 @@ Run `validibot doctor` to get a stage-aware advisory:
 If a Cloud Run Job completes but its callback never reaches Django (network failure, container crash before POST, Cloud Run retry exhaustion), the run gets stuck in `RUNNING` status. The `cleanup_stuck_runs` management command handles this:
 
 1. The command runs every 10 minutes via Cloud Scheduler
-2. It finds runs stuck in `RUNNING` past the timeout threshold (default: 30 minutes)
+2. It finds runs stuck in `RUNNING` past `VALIDATOR_TIMEOUT_SECONDS` (default:
+   3600 seconds / 60 minutes)
 3. For GCP runs, it looks for `execution_name` in `step_run.output` (stored by the launcher at job trigger time)
 4. It queries the Cloud Run Jobs API to check the actual execution status
 5. If the job **succeeded**, it constructs a synthetic callback and processes it through `ValidationCallbackService`, recovering the full validation results
 6. If the job **failed**, it marks the run as `FAILED` with the Cloud Run error
-7. If the job is **still running**, it skips the run (no false timeout)
+7. If the job is **still running after that outer deadline**, it commits the
+   `TIMED_OUT` decision and calls Cloud Run's execution-cancellation operation
 
 ### Where execution metadata is stored
 

--- a/docs/operations/self-hosting/configuration.md
+++ b/docs/operations/self-hosting/configuration.md
@@ -82,7 +82,7 @@ The doctor command's VB001-VB099 range checks these.
 | `VALIDATOR_RUNNER` | `docker` for self-hosted (default). `google_cloud_run` for GCP. |
 | `VALIDATOR_BACKEND_IMAGE_POLICY` | `tag` (default), `digest`, or `signed-digest` (Phase 5). Production: `digest` or higher. Enforced at launch — only enable `digest` once validator images are digest-pinned, or launches fail. |
 | `VALIDATOR_RETAIN_HOURS` | How long stopped validator containers are kept before `cleanup` removes them. Default: `24`. |
-| `VALIDATOR_TIMEOUT_SECONDS` | Default per-validator timeout. Validators can request shorter via their manifest. |
+| `VALIDATOR_TIMEOUT_SECONDS` | Outer per-validator timeout and stuck-run watchdog deadline. Validators can request shorter via their manifest. |
 
 ### 7. Pro and signing
 

--- a/just/gcp/mod.just
+++ b/just/gcp/mod.just
@@ -86,6 +86,10 @@ gcp_cloud_run_request_timeout := env_var_or_default("GCP_CLOUD_RUN_TIMEOUT", "36
 # prod data migration, e.g. GCP_MIGRATE_TIMEOUT=1800s just gcp deploy-all prod
 gcp_migrate_task_timeout := env_var_or_default("GCP_MIGRATE_TIMEOUT", "300s")
 
+# Outer validator Job timeout. The Django watchdog reads the same setting and
+# only fences a run once this provider budget has elapsed.
+gcp_validator_task_timeout := env_var_or_default("VALIDATOR_TIMEOUT_SECONDS", "3600")
+
 # Cloud Scheduler timezone for cron jobs
 gcp_scheduler_timezone := env_var_or_default("GCP_SCHEDULER_TIMEZONE", "UTC")
 
@@ -3579,7 +3583,7 @@ validator-deploy name stage: _require-gcp-config (validator-build-push name)
         --region {{gcp_region}} \
         --service-account "$VALIDATOR_SA" \
         --max-retries 0 \
-        --task-timeout 3600 \
+        --task-timeout {{gcp_validator_task_timeout}} \
         --execution-environment gen2 \
         --network default \
         --subnet default \

--- a/validibot/validations/management/commands/cleanup_stuck_runs.py
+++ b/validibot/validations/management/commands/cleanup_stuck_runs.py
@@ -12,8 +12,9 @@ job succeeded but the callback was lost, it recovers the run by constructing a
 synthetic callback and processing it through the normal callback pipeline. This
 preserves validation results that would otherwise be lost.
 
-If reconciliation is not possible (non-GCP deployment, API errors, or the job
-is still running), the command falls through to marking the run as TIMED_OUT.
+If reconciliation is not possible (non-GCP deployment or API errors), or the
+provider is still running after the configured outer runtime deadline, the
+command marks the run TIMED_OUT and requests provider cancellation.
 
 Usage:
     python manage.py cleanup_stuck_runs
@@ -30,10 +31,13 @@ See also:
 """
 
 import logging
+import math
 from datetime import timedelta
 from http import HTTPStatus
 
+from django.conf import settings
 from django.core.management.base import BaseCommand
+from django.core.management.base import CommandError
 from django.db import transaction
 from django.utils import timezone
 
@@ -42,15 +46,32 @@ from validibot.validations.constants import ValidationRunErrorCategory
 from validibot.validations.constants import ValidationRunStatus
 from validibot.validations.models import ValidationRun
 from validibot.validations.models import ValidationStepRun
+from validibot.validations.services.runners.base import ExecutionStatus
+from validibot.validations.services.validation_run import cancel_active_execution
 
 logger = logging.getLogger(__name__)
 
-# Default timeout: 30 minutes is generous for most validations.
-# EnergyPlus runs can take 5-15 minutes; this gives plenty of buffer.
-DEFAULT_TIMEOUT_MINUTES = 30
+DEFAULT_VALIDATOR_TIMEOUT_SECONDS = 3600
+
+# Cloud Run occasionally reports a terminal failure without diagnostic text.
+# Keep the fallback static and bounded so reconciliation remains truthful
+# without exposing provider payloads to end users.
+PROVIDER_FAILURE_WITHOUT_DETAILS = (
+    "Cloud Run reported a failed execution without diagnostic details"
+)
 
 # Max IDs to display in output before truncating
 MAX_DISPLAY_IDS = 10
+
+
+def get_default_timeout_minutes() -> int:
+    """Return the configured outer validator timeout rounded up to minutes."""
+    timeout_seconds = getattr(
+        settings,
+        "VALIDATOR_TIMEOUT_SECONDS",
+        DEFAULT_VALIDATOR_TIMEOUT_SECONDS,
+    )
+    return max(1, math.ceil(timeout_seconds / 60))
 
 
 class Command(BaseCommand):
@@ -60,10 +81,11 @@ class Command(BaseCommand):
         parser.add_argument(
             "--timeout-minutes",
             type=int,
-            default=DEFAULT_TIMEOUT_MINUTES,
+            default=None,
             help=(
-                f"Consider runs stuck after this many minutes (default: "
-                f"{DEFAULT_TIMEOUT_MINUTES})"
+                "Consider runs stuck after this many minutes. Defaults to the "
+                "configured VALIDATOR_TIMEOUT_SECONDS value "
+                f"({get_default_timeout_minutes()} minutes)."
             ),
         )
         parser.add_argument(
@@ -80,6 +102,10 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         timeout_minutes = options["timeout_minutes"]
+        if timeout_minutes is None:
+            timeout_minutes = get_default_timeout_minutes()
+        if timeout_minutes <= 0:
+            raise CommandError("--timeout-minutes must be greater than zero")
         dry_run = options["dry_run"]
         batch_size = options["batch_size"]
 
@@ -105,8 +131,6 @@ class Command(BaseCommand):
 
         reconciled_ids = []
         timed_out_ids = []
-        skipped_ids = []
-
         error_message = (
             f"Run timed out after {timeout_minutes} minutes - "
             "no callback received from validator. This may indicate the validator "
@@ -119,10 +143,10 @@ class Command(BaseCommand):
             if result == "reconciled":
                 reconciled_ids.append(str(run.id))
                 continue
-            if result == "still_running":
-                skipped_ids.append(str(run.id))
-                continue
-            # result == "not_applicable" or "error" — fall through to timeout
+            # Once the configured outer deadline has elapsed, a provider that
+            # still reports RUNNING must be fenced and canceled rather than
+            # skipped forever. "not_applicable" and API errors also fall
+            # through to the same authoritative timeout decision.
 
             if dry_run:
                 minutes_running = (timezone.now() - run.started_at).total_seconds() / 60
@@ -172,15 +196,25 @@ class Command(BaseCommand):
                     },
                 )
 
+            # The database decision is committed before provider contact. A
+            # cancellation failure is logged by the helper and cannot reopen
+            # the terminal run; durable retries arrive with the attempt model.
+            from validibot.validations.signals import validation_run_finalized
+
+            validation_run_finalized.send_robust(
+                sender=self.__class__,
+                validation_run=locked,
+            )
+            cancel_active_execution(locked)
+
         # Report results
         if dry_run:
-            total = len(reconciled_ids) + len(timed_out_ids) + len(skipped_ids)
+            total = len(reconciled_ids) + len(timed_out_ids)
             self.stdout.write(
                 self.style.WARNING(
                     f"[DRY RUN] {total} stuck run(s): "
                     f"{len(reconciled_ids)} reconcilable, "
-                    f"{len(timed_out_ids)} would time out, "
-                    f"{len(skipped_ids)} still running"
+                    f"{len(timed_out_ids)} would time out"
                 )
             )
         else:
@@ -201,14 +235,7 @@ class Command(BaseCommand):
                 )
                 self._display_ids(timed_out_ids)
 
-            if skipped_ids:
-                self.stdout.write(
-                    self.style.SUCCESS(
-                        f"Skipped {len(skipped_ids)} run(s) still running on GCP."
-                    )
-                )
-
-            if not reconciled_ids and not timed_out_ids and not skipped_ids:
+            if not reconciled_ids and not timed_out_ids:
                 self.stdout.write(self.style.SUCCESS("No runs needed cleanup."))
 
     def _display_ids(self, ids: list[str]) -> None:
@@ -239,7 +266,8 @@ class Command(BaseCommand):
         Returns:
             One of:
             - "reconciled": Run was recovered or marked failed based on GCP status
-            - "still_running": Job is still executing on GCP (skip)
+            - "still_running": Job is still executing on GCP; the caller
+              applies the configured timeout fence and requests cancellation
             - "not_applicable": Not a GCP run or missing metadata
             - "error": GCP API call failed (fall through to timeout)
         """
@@ -274,27 +302,42 @@ class Command(BaseCommand):
         if status_response is None:
             return "error"
 
-        # 4. Act based on status
+        # 4. Act based on the explicit provider state. Human-readable messages
+        # are diagnostics only and must never determine success versus failure.
+        execution_status = status_response.execution_status
+        is_failed = execution_status == ExecutionStatus.FAILED or (
+            execution_status is None and bool(status_response.error_message)
+        )
+        if is_failed:
+            error_message = (
+                status_response.error_message or PROVIDER_FAILURE_WITHOUT_DETAILS
+            )
+            if dry_run:
+                self.stdout.write(
+                    f"  [RECONCILE-FAIL] {run.id}: Cloud Run job failed "
+                    f"({error_message})"
+                )
+                return "reconciled"
+
+            self._mark_run_failed_from_gcp(run, error_message)
+            return "reconciled"
+
         if not status_response.is_complete:
-            # Job is still running — skip, don't time it out
             logger.info(
-                "GCP job still running for run %s (execution=%s), skipping",
+                "GCP job still running beyond the watchdog deadline for run %s "
+                "(execution=%s)",
                 run.id,
                 execution_name,
             )
             return "still_running"
 
-        if status_response.error_message:
-            # Job failed on GCP
-            if dry_run:
-                self.stdout.write(
-                    f"  [RECONCILE-FAIL] {run.id}: Cloud Run job failed "
-                    f"({status_response.error_message})"
-                )
-                return "reconciled"
-
-            self._mark_run_failed_from_gcp(run, status_response.error_message)
-            return "reconciled"
+        if execution_status not in {None, ExecutionStatus.SUCCEEDED}:
+            logger.warning(
+                "Cannot safely reconcile provider state %s for run %s",
+                execution_status,
+                run.id,
+            )
+            return "error"
 
         # Job succeeded — attempt to recover via synthetic callback
         if dry_run:
@@ -336,6 +379,7 @@ class Command(BaseCommand):
         error_message: str,
     ) -> None:
         """Mark a run as failed based on GCP Cloud Run Job failure."""
+        error_message = error_message or PROVIDER_FAILURE_WITHOUT_DETAILS
         with transaction.atomic():
             locked = ValidationRun.objects.select_for_update().get(pk=run.pk)
             if locked.status != ValidationRunStatus.RUNNING:
@@ -372,6 +416,13 @@ class Command(BaseCommand):
                     "error_message": error_message,
                 },
             )
+
+        from validibot.validations.signals import validation_run_finalized
+
+        validation_run_finalized.send_robust(
+            sender=self.__class__,
+            validation_run=locked,
+        )
 
     def _recover_lost_callback(
         self,

--- a/validibot/validations/services/execution/base.py
+++ b/validibot/validations/services/execution/base.py
@@ -34,6 +34,7 @@ if TYPE_CHECKING:
     from validibot.submissions.models import Submission
     from validibot.validations.models import ValidationRun
     from validibot.validations.models import Validator
+    from validibot.validations.services.runners.base import ExecutionStatus
     from validibot.workflows.models import WorkflowStep
 
 logger = logging.getLogger(__name__)
@@ -123,6 +124,16 @@ class ExecutionResponse:
     Trust ADR Phase 5 Session A — sync backends populate this from
     the runner's :class:`ExecutionResult`; async backends persist it
     on the step run directly at launch time and leave this ``None``.
+    """
+
+    execution_status: ExecutionStatus | None = None
+    """Provider-neutral execution state.
+
+    Callers must use this field, rather than the presence of human-readable
+    error text, when deciding whether a completed execution succeeded.
+    ``None`` remains available for legacy responses during the compatibility
+    window. It is appended to preserve the positional constructor used by any
+    older integration.
     """
 
 

--- a/validibot/validations/services/execution/docker_compose.py
+++ b/validibot/validations/services/execution/docker_compose.py
@@ -139,7 +139,9 @@ class DockerComposeExecutionBackend(ExecutionBackend):
             in (
                 ExecutionStatus.SUCCEEDED,
                 ExecutionStatus.FAILED,
+                ExecutionStatus.CANCELLED,
             ),
+            execution_status=info.status,
             error_message=info.error_message,
         )
 

--- a/validibot/validations/services/execution/gcp.py
+++ b/validibot/validations/services/execution/gcp.py
@@ -144,7 +144,9 @@ class GCPExecutionBackend(ExecutionBackend):
             in (
                 ExecutionStatus.SUCCEEDED,
                 ExecutionStatus.FAILED,
+                ExecutionStatus.CANCELLED,
             ),
+            execution_status=info.status,
             error_message=info.error_message,
         )
 

--- a/validibot/validations/services/runners/google_cloud_run.py
+++ b/validibot/validations/services/runners/google_cloud_run.py
@@ -290,12 +290,19 @@ class GoogleCloudRunValidatorRunner(ValidatorRunner):
 
         # Map Cloud Run condition to ExecutionStatus
         status = ExecutionStatus.UNKNOWN
+        error_message = None
         for condition in execution.conditions:
             if condition.type_ == "Completed":
-                if condition.state == run_v2.Condition.State.CONDITION_SUCCEEDED:
+                if (
+                    condition.execution_reason
+                    == run_v2.Condition.ExecutionReason.CANCELLED
+                ):
+                    status = ExecutionStatus.CANCELLED
+                elif condition.state == run_v2.Condition.State.CONDITION_SUCCEEDED:
                     status = ExecutionStatus.SUCCEEDED
                 elif condition.state == run_v2.Condition.State.CONDITION_FAILED:
                     status = ExecutionStatus.FAILED
+                    error_message = condition.message or None
                 break
 
         # If no completion condition, infer running/pending
@@ -312,26 +319,32 @@ class GoogleCloudRunValidatorRunner(ValidatorRunner):
             end_time=(
                 str(execution.completion_time) if execution.completion_time else None
             ),
+            error_message=error_message,
         )
 
     def cancel(self, execution_id: str) -> bool:
         """
         Cancel a Cloud Run Job execution.
 
-        Cloud Run Jobs support cancellation via the delete operation on
-        the execution.
+        Cloud Run Jobs expose a distinct cancellation operation. Deleting an
+        execution is retention cleanup and does not request active work to stop.
 
         Args:
             execution_id: Full execution name from run()
 
         Returns:
-            True if cancellation was successful, False otherwise
+            True if the cancellation request was accepted, False otherwise.
+            The API returns a long-running operation; this method deliberately
+            does not wait for provider completion in the caller's request path.
         """
         client = self._get_executions_client()
 
         try:
-            client.delete_execution(name=execution_id)
-            logger.info("Cancelled Cloud Run execution: %s", execution_id)
+            client.cancel_execution(name=execution_id)
+            logger.info(
+                "Requested cancellation of Cloud Run execution: %s",
+                execution_id,
+            )
         except Exception as e:
             logger.warning("Failed to cancel execution %s: %s", execution_id, e)
             return False

--- a/validibot/validations/services/validation_callback.py
+++ b/validibot/validations/services/validation_callback.py
@@ -34,6 +34,7 @@ from validibot_shared.validations.envelopes import ValidationCallback
 from validibot_shared.validations.envelopes import ValidationStatus
 
 from validibot.core.models import CallbackReceiptStatus
+from validibot.validations.constants import VALIDATION_RUN_TERMINAL_STATUSES
 from validibot.validations.constants import StepStatus
 from validibot.validations.constants import ValidationRunErrorCategory
 from validibot.validations.constants import ValidationRunStatus
@@ -212,6 +213,26 @@ class ValidationCallbackService:
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR,
             )
 
+    @staticmethod
+    def _late_callback_response(
+        callback: ValidationCallback,
+        run: ValidationRun,
+    ) -> Response:
+        """Acknowledge output that arrived after the run became terminal."""
+        logger.info(
+            "Ignoring late callback for terminal run %s (status=%s, callback_id=%s)",
+            run.id,
+            run.status,
+            callback.callback_id,
+        )
+        return Response(
+            {
+                "message": "Run is already terminal",
+                "late_callback_ignored": True,
+            },
+            status=status.HTTP_200_OK,
+        )
+
     # ── Idempotency guard ─────────────────────────────────────────────
 
     def _process_with_idempotency_guard(
@@ -238,6 +259,9 @@ class ValidationCallbackService:
            409 so Cloud Tasks retries later.
         """
         if not callback.callback_id:
+            run.refresh_from_db(fields=["status"])
+            if run.status in VALIDATION_RUN_TERMINAL_STATUSES:
+                return self._late_callback_response(callback, run)
             return self._process_callback(
                 callback=callback,
                 run=run,
@@ -286,6 +310,16 @@ class ValidationCallbackService:
                         "failed), retrying",
                         callback.callback_id,
                     )
+
+                # Preserve the existing idempotent response above for a true
+                # duplicate receipt. For a new/dangling receipt, refresh the
+                # authoritative run before any storage read; if cancellation,
+                # timeout, or another callback already won, close the receipt
+                # and acknowledge without processing stale output.
+                run.refresh_from_db(fields=["status"])
+                if run.status in VALIDATION_RUN_TERMINAL_STATUSES:
+                    self._mark_receipt_completed(callback, receipt, run)
+                    return self._late_callback_response(callback, run)
 
                 # Process inside the transaction so the row lock is held
                 # until the receipt status reaches a terminal value.
@@ -712,6 +746,19 @@ class ValidationCallbackService:
         """
         from validibot.core.tasks import enqueue_validation_run
 
+        if not ValidationRun.objects.filter(
+            pk=run.pk,
+            status__in=[
+                ValidationRunStatus.PENDING,
+                ValidationRunStatus.RUNNING,
+            ],
+        ).exists():
+            logger.info(
+                "Not enqueuing the next step for terminal run %s",
+                run.id,
+            )
+            return
+
         # NOTE: resume_from_step here is the *completed* step's order, not
         # the next step's order. The orchestrator uses order__gt (not __gte)
         # to skip it and start from the next one. This avoids fabricating a
@@ -768,31 +815,51 @@ class ValidationCallbackService:
             result.output_envelope.timing.finished_at,
         )
 
-        run.status = step_to_run_status.get(
+        target_status = step_to_run_status.get(
             result.step_status,
             ValidationRunStatus.FAILED,
         )
+        duration_ms = run.duration_ms
+
+        if run.started_at and finished_at:
+            delta = finished_at - run.started_at
+            duration_ms = int(delta.total_seconds() * 1000)
+
+        # Optimistic terminal fence: callback admission and output processing
+        # cannot hold a database lock across storage/provider work. Make the
+        # final transition conditional instead, so a concurrent cancel or
+        # watchdog timeout wins without a stale model save resurrecting it.
+        updated = ValidationRun.objects.filter(
+            pk=run.pk,
+            status__in=[
+                ValidationRunStatus.PENDING,
+                ValidationRunStatus.RUNNING,
+            ],
+        ).update(
+            status=target_status,
+            error_category=error_category,
+            ended_at=finished_at,
+            error=result.step_error,
+            duration_ms=duration_ms,
+        )
+        if updated == 0:
+            run.refresh_from_db(
+                fields=["status", "error_category", "ended_at", "error", "duration_ms"]
+            )
+            logger.info(
+                "Ignored callback finalization for terminal run %s (status=%s)",
+                run.id,
+                run.status,
+            )
+            return
+
+        # Keep the model passed to downstream signals/projections aligned with
+        # the conditional database update without another query.
+        run.status = target_status
         run.error_category = error_category
         run.ended_at = finished_at
         run.error = result.step_error
-
-        if run.started_at and run.ended_at:
-            delta = run.ended_at - run.started_at
-            run.duration_ms = int(delta.total_seconds() * 1000)
-
-        # Save only the fields this finalization path actually mutates. Every
-        # other ValidationRun.save() uses update_fields (see receipt.save()
-        # below); a bare save() here writes the whole in-memory row and can
-        # clobber a concurrent write (e.g. a parallel cancel toggling status).
-        run.save(
-            update_fields=[
-                "status",
-                "error_category",
-                "ended_at",
-                "error",
-                "duration_ms",
-            ],
-        )
+        run.duration_ms = duration_ms
 
         # Notify listeners that the run reached a terminal status (e.g. cloud
         # metering releases the compute-credit reservation). send_robust so a

--- a/validibot/validations/services/validation_run.py
+++ b/validibot/validations/services/validation_run.py
@@ -50,11 +50,13 @@ from rest_framework import status
 from validibot.submissions.constants import get_output_retention_timedelta
 from validibot.tracking.services import TrackingEventService
 from validibot.validations.constants import VALIDATION_RUN_TERMINAL_STATUSES
+from validibot.validations.constants import StepStatus
 from validibot.validations.constants import ValidationRunSource
 from validibot.validations.constants import ValidationRunStatus
 from validibot.validations.exceptions import OrgPolicyDeniedError
 from validibot.validations.models import ValidationRun
 from validibot.validations.models import ValidationRunSummary
+from validibot.validations.models import ValidationStepRun
 from validibot.validations.services.step_orchestrator import StepOrchestrator
 
 logger = logging.getLogger(__name__)
@@ -84,6 +86,65 @@ def _send_run_created_signal(validation_run: ValidationRun, workflow_type: str) 
         validation_run=validation_run,
         workflow_type=workflow_type,
     )
+
+
+def cancel_active_execution(run: ValidationRun) -> bool | None:
+    """Best-effort cancel the concrete provider execution for an active step.
+
+    The caller must commit the run's logical terminal state before invoking
+    this helper. Provider APIs and PostgreSQL cannot share a transaction, so a
+    provider failure is logged and returned without reopening the run. ``None``
+    means the legacy run has no addressable execution identity.
+    """
+    step_run = (
+        ValidationStepRun.objects.filter(
+            validation_run=run,
+            status__in=[StepStatus.RUNNING, StepStatus.PENDING],
+        )
+        .order_by("step_order")
+        .first()
+    )
+    if not step_run:
+        return None
+
+    step_output = step_run.output or {}
+    execution_id = step_output.get("execution_name") or step_output.get("execution_id")
+    if not execution_id:
+        return None
+
+    try:
+        from validibot.validations.services.runners import get_validator_runner
+
+        canceled = get_validator_runner().cancel(execution_id)
+    except Exception:
+        logger.warning(
+            "Failed to request provider cancellation",
+            extra={
+                "run_id": str(run.id),
+                "execution_id": execution_id,
+            },
+            exc_info=True,
+        )
+        return False
+
+    if not canceled:
+        logger.warning(
+            "Provider did not accept execution cancellation",
+            extra={
+                "run_id": str(run.id),
+                "execution_id": execution_id,
+            },
+        )
+        return False
+
+    logger.info(
+        "Requested provider execution cancellation",
+        extra={
+            "run_id": str(run.id),
+            "execution_id": execution_id,
+        },
+    )
+    return True
 
 
 @dataclass
@@ -390,38 +451,50 @@ class ValidationRunService:
         run: ValidationRun,
         actor: User | None = None,
     ) -> tuple[ValidationRun, bool]:
-        """Attempt to cancel a validation run if it has not finished yet."""
+        """Fence a validation run, then stop any known provider execution."""
 
         if run is None:
             raise ValueError("run is required to cancel a validation")
 
-        run.refresh_from_db()
-        if run.status == ValidationRunStatus.CANCELED:
-            return run, True
+        with transaction.atomic():
+            locked_run = ValidationRun.objects.select_for_update().get(pk=run.pk)
+            if locked_run.status == ValidationRunStatus.CANCELED:
+                return locked_run, True
 
-        if run.status not in (
-            ValidationRunStatus.PENDING,
-            ValidationRunStatus.RUNNING,
-        ):
-            return run, False
+            if locked_run.status not in (
+                ValidationRunStatus.PENDING,
+                ValidationRunStatus.RUNNING,
+            ):
+                return locked_run, False
 
-        run.status = ValidationRunStatus.CANCELED
-        if not run.ended_at:
-            run.ended_at = timezone.now()
-        if not run.error:
-            run.error = RUN_CANCELED_MESSAGE
-        run.save(update_fields=["status", "ended_at", "error"])
+            locked_run.status = ValidationRunStatus.CANCELED
+            if not locked_run.ended_at:
+                locked_run.ended_at = timezone.now()
+            if not locked_run.error:
+                locked_run.error = RUN_CANCELED_MESSAGE
+            locked_run.save(update_fields=["status", "ended_at", "error"])
+
+        # External work stays outside the database transaction. The terminal
+        # decision is authoritative even if the provider is unavailable.
+        cancel_active_execution(locked_run)
 
         tracking_service = TrackingEventService()
-        extra = {"duration_ms": run.computed_duration_ms}
+        extra = {"duration_ms": locked_run.computed_duration_ms}
         tracking_service.log_validation_run_status(
-            run=run,
+            run=locked_run,
             status=ValidationRunStatus.CANCELED,
             actor=actor,
             extra_data=extra,
         )
 
-        return run, True
+        from validibot.validations.signals import validation_run_finalized
+
+        validation_run_finalized.send_robust(
+            sender=self.__class__,
+            validation_run=locked_run,
+        )
+
+        return locked_run, True
 
     # ---------- Delegated to StepOrchestrator ----------
 

--- a/validibot/validations/tests/services/test_check_status.py
+++ b/validibot/validations/tests/services/test_check_status.py
@@ -69,6 +69,7 @@ class TestDockerCheckStatus(SimpleTestCase):
         assert isinstance(result, ExecutionResponse)
         assert result.execution_id == "container-123"
         assert result.is_complete is True
+        assert result.execution_status == ExecutionStatus.SUCCEEDED
         assert result.error_message is None
         mock_runner.get_execution_status.assert_called_once_with("container-123")
 
@@ -89,6 +90,7 @@ class TestDockerCheckStatus(SimpleTestCase):
 
         assert result is not None
         assert result.is_complete is False
+        assert result.execution_status == ExecutionStatus.RUNNING
 
     @patch(
         "validibot.validations.services.execution.docker_compose.get_validator_runner"
@@ -108,6 +110,7 @@ class TestDockerCheckStatus(SimpleTestCase):
 
         assert result is not None
         assert result.is_complete is True
+        assert result.execution_status == ExecutionStatus.FAILED
         assert result.error_message == "OOM killed"
 
     @patch(
@@ -157,6 +160,7 @@ class TestDockerCheckStatus(SimpleTestCase):
 
         assert result is not None
         assert result.is_complete is False
+        assert result.execution_status == ExecutionStatus.PENDING
 
 
 class TestGCPCheckStatus(SimpleTestCase):
@@ -191,6 +195,7 @@ class TestGCPCheckStatus(SimpleTestCase):
         assert result is not None
         assert isinstance(result, ExecutionResponse)
         assert result.is_complete is True
+        assert result.execution_status == ExecutionStatus.SUCCEEDED
         assert result.error_message is None
         mock_runner_cls.assert_called_once_with(
             project_id="test-project",
@@ -215,6 +220,7 @@ class TestGCPCheckStatus(SimpleTestCase):
 
         assert result is not None
         assert result.is_complete is False
+        assert result.execution_status == ExecutionStatus.RUNNING
 
     @patch(RUNNER_PATH)
     def test_check_status_failed_maps_to_complete_with_error(self, mock_runner_cls):
@@ -235,7 +241,39 @@ class TestGCPCheckStatus(SimpleTestCase):
 
         assert result is not None
         assert result.is_complete is True
+        assert result.execution_status == ExecutionStatus.FAILED
         assert result.error_message == "Container OOM killed"
+
+    @patch(RUNNER_PATH)
+    def test_check_status_preserves_failed_without_diagnostic_text(
+        self,
+        mock_runner_cls,
+    ):
+        """A provider failure must remain explicit when its message is empty.
+
+        Reconciliation decides whether to recover a successful output or mark
+        infrastructure failure. If the backend carries only message text, an
+        empty Cloud Run diagnostic is indistinguishable from success and can
+        send a failed execution down the synthetic-callback path.
+        """
+        mock_runner_instance = MagicMock()
+        mock_runner_instance.get_execution_status.return_value = ExecutionInfo(
+            execution_id="projects/p/locations/r/jobs/j/executions/e",
+            status=ExecutionStatus.FAILED,
+            error_message=None,
+        )
+        mock_runner_cls.return_value = mock_runner_instance
+
+        backend = GCPExecutionBackend()
+        backend._project_id = "test-project"
+        backend._region = "us-central1"
+
+        result = backend.check_status("projects/p/locations/r/jobs/j/executions/e")
+
+        assert result is not None
+        assert result.is_complete is True
+        assert result.execution_status == ExecutionStatus.FAILED
+        assert result.error_message is None
 
     def test_check_status_handles_import_error(self):
         """Returns None when google-cloud-run is not installed."""

--- a/validibot/validations/tests/services/test_execution_backends.py
+++ b/validibot/validations/tests/services/test_execution_backends.py
@@ -229,6 +229,21 @@ class TestExecutionResponse:
         assert response.is_complete is False
         assert response.output_envelope is None
         assert response.error_message is None
+        assert response.execution_status is None
+
+    def test_execution_status_addition_preserves_legacy_positional_arguments(self):
+        """Older integrations must not reinterpret their third argument.
+
+        ``execution_status`` is an additive reader-first field. Appending it to
+        the dataclass keeps a positional ``output_envelope`` argument in its
+        historical slot instead of silently treating the envelope as a status.
+        """
+        envelope = object()
+
+        response = ExecutionResponse("exec-legacy", True, envelope)  # noqa: FBT003
+
+        assert response.output_envelope is envelope
+        assert response.execution_status is None
 
 
 # ==============================================================================

--- a/validibot/validations/tests/services/test_google_cloud_run_runner.py
+++ b/validibot/validations/tests/services/test_google_cloud_run_runner.py
@@ -1,0 +1,124 @@
+"""Tests for Cloud Run execution status and cancellation semantics.
+
+Cloud Run exposes deletion and cancellation as separate operations. Deletion
+removes the execution resource; cancellation is the operation that requests
+active compute to stop. These tests keep the runner on the cost- and
+lifecycle-correct API without requiring live Google credentials.
+"""
+
+from unittest.mock import MagicMock
+
+from django.test import SimpleTestCase
+from google.cloud import run_v2
+
+from validibot.validations.services.runners.base import ExecutionStatus
+from validibot.validations.services.runners.google_cloud_run import (
+    GoogleCloudRunValidatorRunner,
+)
+
+
+class TestGoogleCloudRunCancellation(SimpleTestCase):
+    """Map logical cancellation to Cloud Run's execution-cancel API."""
+
+    def test_cancel_requests_execution_cancellation_without_deleting_record(self):
+        """Stopping active compute must preserve its provider execution record.
+
+        Deleting an execution is a retention operation and is not a substitute
+        for cancellation. Keeping the resource also leaves provider evidence
+        available for reconciliation and incident review.
+        """
+        execution_id = "projects/p/locations/r/jobs/j/executions/e"
+        client = MagicMock()
+        runner = GoogleCloudRunValidatorRunner(
+            project_id="test-project",
+            region="us-central1",
+        )
+        runner._executions_client = client
+
+        cancelled = runner.cancel(execution_id)
+
+        assert cancelled is True
+        client.cancel_execution.assert_called_once_with(name=execution_id)
+        client.delete_execution.assert_not_called()
+
+    def test_cancel_api_failure_is_reported_without_raising(self):
+        """A provider outage must not undo Validibot's logical cancellation.
+
+        Cancellation is best-effort until durable lifecycle work lands. The
+        runner therefore reports failure to its caller while leaving the
+        already-committed run decision intact and the provider failure visible.
+        """
+        execution_id = "projects/p/locations/r/jobs/j/executions/e"
+        client = MagicMock()
+        client.cancel_execution.side_effect = RuntimeError("API unavailable")
+        runner = GoogleCloudRunValidatorRunner(
+            project_id="test-project",
+            region="us-central1",
+        )
+        runner._executions_client = client
+
+        cancelled = runner.cancel(execution_id)
+
+        assert cancelled is False
+        client.cancel_execution.assert_called_once_with(name=execution_id)
+
+
+class TestGoogleCloudRunStatus(SimpleTestCase):
+    """Preserve Cloud Run terminal state independently of diagnostics."""
+
+    def test_failed_condition_keeps_status_when_message_is_empty(self):
+        """Failure state must survive an empty human-readable diagnostic.
+
+        Reconciliation consumes this explicit status; losing it would make the
+        failed execution indistinguishable from a successful job whose callback
+        was lost.
+        """
+        condition = MagicMock()
+        condition.type_ = "Completed"
+        condition.state = run_v2.Condition.State.CONDITION_FAILED
+        condition.execution_reason = run_v2.Condition.ExecutionReason.NON_ZERO_EXIT_CODE
+        condition.message = ""
+        execution = MagicMock()
+        execution.conditions = [condition]
+        execution.start_time = "start"
+        execution.completion_time = "finish"
+        client = MagicMock()
+        client.get_execution.return_value = execution
+        runner = GoogleCloudRunValidatorRunner(
+            project_id="test-project",
+            region="us-central1",
+        )
+        runner._executions_client = client
+
+        info = runner.get_execution_status("execution-123")
+
+        assert info.status == ExecutionStatus.FAILED
+        assert info.error_message is None
+
+    def test_cancelled_condition_is_not_collapsed_into_failure(self):
+        """Provider cancellation remains distinguishable from execution error.
+
+        Cloud Run represents cancellation using a failed Completed condition
+        plus a specific execution reason. Reading only the generic condition
+        state would erase the lifecycle event that Validibot requested.
+        """
+        condition = MagicMock()
+        condition.type_ = "Completed"
+        condition.state = run_v2.Condition.State.CONDITION_FAILED
+        condition.execution_reason = run_v2.Condition.ExecutionReason.CANCELLED
+        condition.message = "Execution was cancelled"
+        execution = MagicMock()
+        execution.conditions = [condition]
+        execution.start_time = "start"
+        execution.completion_time = "finish"
+        client = MagicMock()
+        client.get_execution.return_value = execution
+        runner = GoogleCloudRunValidatorRunner(
+            project_id="test-project",
+            region="us-central1",
+        )
+        runner._executions_client = client
+
+        info = runner.get_execution_status("execution-123")
+
+        assert info.status == ExecutionStatus.CANCELLED

--- a/validibot/validations/tests/test_callback_terminal_fencing.py
+++ b/validibot/validations/tests/test_callback_terminal_fencing.py
@@ -1,0 +1,83 @@
+"""Regression tests for callbacks racing terminal run decisions.
+
+Callbacks are asynchronous and can arrive after user cancellation or watchdog
+timeout. Those deliveries may be acknowledged, but they must not download or
+apply outputs, enqueue more work, or overwrite the terminal decision with a
+stale in-memory RUNNING run.
+"""
+
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+from django.utils import timezone
+from rest_framework import status
+from validibot_shared.validations.envelopes import ValidationStatus
+
+from validibot.validations.constants import StepStatus
+from validibot.validations.constants import ValidationRunStatus
+from validibot.validations.models import ValidationRun
+from validibot.validations.services.validation_callback import ValidationCallbackService
+from validibot.validations.tests.factories import ValidationRunFactory
+
+
+@pytest.mark.django_db
+class TestCallbackTerminalFencing:
+    """Prove callback delivery cannot reopen a terminal validation run."""
+
+    @pytest.mark.parametrize(
+        "terminal_status",
+        [ValidationRunStatus.CANCELED, ValidationRunStatus.TIMED_OUT],
+    )
+    def test_callback_for_terminal_run_is_acknowledged_without_processing(
+        self,
+        terminal_status,
+    ):
+        """Late callbacks must stop before storage reads or step mutation.
+
+        Returning 200 prevents pointless provider retries, while bypassing the
+        processing pipeline preserves cancellation/timeout as the authoritative
+        outcome and avoids trusting stale output after the deadline.
+        """
+        run = ValidationRunFactory(status=terminal_status)
+        service = ValidationCallbackService()
+
+        with patch.object(service, "_process_callback") as process:
+            response = service.process(
+                payload={
+                    "run_id": str(run.id),
+                    "callback_id": f"late-{run.id}",
+                    "status": "success",
+                    "result_uri": "gs://bucket/output.json",
+                }
+            )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data["late_callback_ignored"] is True
+        process.assert_not_called()
+
+    def test_finalization_compare_and_set_preserves_concurrent_cancel(self):
+        """A cancel winning after callback admission must remain terminal.
+
+        The callback holds a stale RUNNING model instance in this race. Its
+        final write must be conditional on the database still being active;
+        an ordinary model save would overwrite the concurrent CANCELED state.
+        """
+        run = ValidationRunFactory(
+            status=ValidationRunStatus.RUNNING,
+            started_at=timezone.now(),
+        )
+        stale_run = ValidationRun.objects.get(pk=run.pk)
+        ValidationRun.objects.filter(pk=run.pk).update(
+            status=ValidationRunStatus.CANCELED,
+        )
+        result = MagicMock()
+        result.step_status = StepStatus.PASSED
+        result.step_error = ""
+        result.output_envelope.status = ValidationStatus.SUCCESS
+        result.output_envelope.timing.finished_at = timezone.now()
+
+        ValidationCallbackService()._finalize_run(stale_run, result)
+
+        run.refresh_from_db()
+        assert run.status == ValidationRunStatus.CANCELED

--- a/validibot/validations/tests/test_gcp_reconciliation.py
+++ b/validibot/validations/tests/test_gcp_reconciliation.py
@@ -15,13 +15,18 @@ from unittest.mock import MagicMock
 from unittest.mock import patch
 
 from django.test import SimpleTestCase
+from django.test import override_settings
 from django.utils import timezone
 
 from validibot.validations.constants import StepStatus
 from validibot.validations.constants import ValidationRunErrorCategory
 from validibot.validations.constants import ValidationRunStatus
 from validibot.validations.management.commands.cleanup_stuck_runs import Command
+from validibot.validations.management.commands.cleanup_stuck_runs import (
+    get_default_timeout_minutes,
+)
 from validibot.validations.services.execution.base import ExecutionResponse
+from validibot.validations.services.runners.base import ExecutionStatus
 
 CMD_PATH = "validibot.validations.management.commands.cleanup_stuck_runs"
 
@@ -30,6 +35,20 @@ GCP_BACKEND_PATH = "validibot.validations.services.execution.gcp.GCPExecutionBac
 CALLBACK_SVC_PATH = (
     "validibot.validations.services.validation_callback.ValidationCallbackService"
 )
+
+
+class TestWatchdogTimeoutConfiguration(SimpleTestCase):
+    """Keep the watchdog deadline aligned with the outer runtime budget."""
+
+    @override_settings(VALIDATOR_TIMEOUT_SECONDS=3601)
+    def test_configured_seconds_round_up_to_a_safe_minute_deadline(self):
+        """The watchdog must never fence a run before its provider timeout.
+
+        The command accepts minutes while the shared runtime setting uses
+        seconds. Rounding down would create a window where valid provider work
+        is canceled before the configured outer execution budget expires.
+        """
+        assert get_default_timeout_minutes() == 61  # noqa: PLR2004
 
 
 def _mock_run(*, step_output=None, minutes_ago=45, status=ValidationRunStatus.RUNNING):
@@ -147,6 +166,7 @@ class TestReconcileMarksFailed(SimpleTestCase):
         mock_backend.check_status.return_value = ExecutionResponse(
             execution_id="projects/p/locations/r/jobs/j/executions/e",
             is_complete=True,
+            execution_status=ExecutionStatus.FAILED,
             error_message="Container OOM killed",
         )
         mock_backend_cls.return_value = mock_backend
@@ -168,6 +188,51 @@ class TestReconcileMarksFailed(SimpleTestCase):
 
         assert result == "reconciled"
         mock_mark_failed.assert_called_once_with(run, "Container OOM killed")
+
+    @patch(f"{CMD_PATH}.Command._is_gcp_deployment", return_value=True)
+    @patch(GCP_BACKEND_PATH)
+    def test_reconcile_preserves_failed_job_without_message(
+        self,
+        mock_backend_cls,
+        mock_is_gcp,
+    ):
+        """An empty provider diagnostic must never turn failure into success.
+
+        Cloud Run can report a terminal FAILED condition without useful text.
+        Reconciliation must use the explicit state and a bounded fallback
+        message, never attempt to download a nonexistent successful output.
+        """
+        mock_backend = MagicMock()
+        mock_backend.check_status.return_value = ExecutionResponse(
+            execution_id="projects/p/locations/r/jobs/j/executions/e",
+            is_complete=True,
+            execution_status=ExecutionStatus.FAILED,
+            error_message=None,
+        )
+        mock_backend_cls.return_value = mock_backend
+
+        run = _mock_run()
+        step_run = _mock_step_run(
+            output={
+                "execution_name": "projects/p/locations/r/jobs/j/executions/e",
+                "execution_bundle_uri": "gs://bucket/runs/org/run-id",
+            }
+        )
+
+        cmd = Command()
+        with (
+            patch.object(cmd, "_get_active_step_run", return_value=step_run),
+            patch.object(cmd, "_mark_run_failed_from_gcp") as mock_mark_failed,
+            patch.object(cmd, "_recover_lost_callback") as mock_recover,
+        ):
+            result = cmd._try_reconcile_gcp_run(run)
+
+        assert result == "reconciled"
+        mock_mark_failed.assert_called_once_with(
+            run,
+            "Cloud Run reported a failed execution without diagnostic details",
+        )
+        mock_recover.assert_not_called()
 
 
 class TestMarkRunFailedFromGCP(SimpleTestCase):
@@ -515,14 +580,27 @@ class TestCommandHandle(SimpleTestCase):
     @patch(f"{CMD_PATH}.ValidationRun")
     @patch(f"{CMD_PATH}.Command._is_gcp_deployment", return_value=True)
     @patch(GCP_BACKEND_PATH)
-    def test_command_skips_still_running_jobs(
-        self, mock_backend_cls, mock_is_gcp, mock_run_model
+    @patch(f"{CMD_PATH}.transaction")
+    @patch(f"{CMD_PATH}.cancel_active_execution")
+    def test_command_fences_and_cancels_still_running_jobs_after_deadline(
+        self,
+        mock_cancel,
+        mock_transaction,
+        mock_backend_cls,
+        mock_is_gcp,
+        mock_run_model,
     ):
-        """Still-running GCP jobs should be skipped (not timed out)."""
+        """Known-running provider work must be stopped after its outer deadline.
+
+        Skipping a provider that remains RUNNING after the configured maximum
+        leaves unbounded compute and a run that can never become terminal. The
+        watchdog first commits TIMED_OUT, then requests provider cancellation.
+        """
         mock_backend = MagicMock()
         mock_backend.check_status.return_value = ExecutionResponse(
             execution_id="projects/p/locations/r/jobs/j/executions/e",
             is_complete=False,
+            execution_status=ExecutionStatus.RUNNING,
         )
         mock_backend_cls.return_value = mock_backend
 
@@ -539,6 +617,15 @@ class TestCommandHandle(SimpleTestCase):
         mock_qs.__iter__ = MagicMock(return_value=iter([run]))
         _wire_stuck_runs_qs(mock_run_model, mock_qs)
 
+        locked_run = MagicMock()
+        locked_run.status = ValidationRunStatus.RUNNING
+        locked_run.started_at = run.started_at
+        mock_run_model.objects.select_for_update.return_value.get.return_value = (
+            locked_run
+        )
+        mock_transaction.atomic.return_value.__enter__ = MagicMock(return_value=None)
+        mock_transaction.atomic.return_value.__exit__ = MagicMock(return_value=False)
+
         out = StringIO()
         cmd = Command()
         cmd.stdout = out
@@ -550,13 +637,20 @@ class TestCommandHandle(SimpleTestCase):
             cmd.handle(timeout_minutes=30, dry_run=False, batch_size=100)
 
         output = out.getvalue()
-        assert "still running" in output.lower()
+        assert locked_run.status == ValidationRunStatus.TIMED_OUT
+        assert "Marked 1 stuck run(s) as TIMED_OUT" in output
+        mock_cancel.assert_called_once_with(locked_run)
 
     @patch(f"{CMD_PATH}.ValidationRun")
     @patch(f"{CMD_PATH}.Command._is_gcp_deployment", return_value=False)
     @patch(f"{CMD_PATH}.transaction")
+    @patch(f"{CMD_PATH}.cancel_active_execution")
     def test_non_gcp_runs_are_timed_out(
-        self, mock_transaction, mock_is_gcp, mock_run_model
+        self,
+        mock_cancel,
+        mock_transaction,
+        mock_is_gcp,
+        mock_run_model,
     ):
         """Non-GCP runs should be timed out as before (no reconciliation)."""
         run = _mock_run()
@@ -589,6 +683,7 @@ class TestCommandHandle(SimpleTestCase):
         assert locked_run.status == ValidationRunStatus.TIMED_OUT
         assert locked_run.error_category == ValidationRunErrorCategory.TIMEOUT
         locked_run.save.assert_called_once()
+        mock_cancel.assert_called_once_with(locked_run)
 
     @patch(f"{CMD_PATH}.ValidationRun")
     @patch(f"{CMD_PATH}.Command._is_gcp_deployment", return_value=False)

--- a/validibot/validations/tests/test_run_cancellation.py
+++ b/validibot/validations/tests/test_run_cancellation.py
@@ -1,0 +1,81 @@
+"""Regression tests for logical and provider validation-run cancellation.
+
+The database decision is authoritative and must commit even when an external
+runner is unavailable. When a concrete execution identity is known, Validibot
+should then ask the configured runner to stop that work so canceled runs do not
+continue consuming resources.
+"""
+
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+
+from validibot.validations.constants import StepStatus
+from validibot.validations.constants import ValidationRunStatus
+from validibot.validations.services.validation_run import ValidationRunService
+from validibot.validations.tests.factories import ValidationRunFactory
+from validibot.validations.tests.factories import ValidationStepRunFactory
+
+RUNNER_FACTORY_PATH = "validibot.validations.services.runners.get_validator_runner"
+
+
+@pytest.mark.django_db
+class TestValidationRunCancellation:
+    """Keep user-visible cancellation authoritative over provider effects."""
+
+    @patch(RUNNER_FACTORY_PATH)
+    def test_running_execution_is_canceled_after_run_is_fenced(
+        self,
+        mock_get_runner,
+    ):
+        """A known execution must be stopped after the run becomes CANCELED.
+
+        The runner call observes the database's terminal decision, ensuring a
+        provider failure cannot roll back user intent or let a late callback
+        legitimately reopen the run.
+        """
+        execution_id = "projects/p/locations/r/jobs/j/executions/e"
+        run = ValidationRunFactory(status=ValidationRunStatus.RUNNING)
+        ValidationStepRunFactory(
+            validation_run=run,
+            status=StepStatus.RUNNING,
+            output={"execution_name": execution_id},
+        )
+        runner = MagicMock()
+        runner.cancel.return_value = True
+        mock_get_runner.return_value = runner
+
+        updated_run, canceled = ValidationRunService().cancel_run(run=run)
+
+        assert canceled is True
+        updated_run.refresh_from_db()
+        assert updated_run.status == ValidationRunStatus.CANCELED
+        runner.cancel.assert_called_once_with(execution_id)
+
+    @patch(RUNNER_FACTORY_PATH)
+    def test_provider_failure_does_not_undo_logical_cancellation(
+        self,
+        mock_get_runner,
+    ):
+        """An unavailable provider must leave the run terminally canceled.
+
+        PostgreSQL and the provider cannot share a transaction. The safe order
+        is to commit the logical fence first and treat external cancellation
+        failure as observable cleanup work rather than reopening the run.
+        """
+        run = ValidationRunFactory(status=ValidationRunStatus.RUNNING)
+        ValidationStepRunFactory(
+            validation_run=run,
+            status=StepStatus.RUNNING,
+            output={"execution_name": "execution-123"},
+        )
+        runner = MagicMock()
+        runner.cancel.return_value = False
+        mock_get_runner.return_value = runner
+
+        _, canceled = ValidationRunService().cancel_run(run=run)
+
+        assert canceled is True
+        run.refresh_from_db()
+        assert run.status == ValidationRunStatus.CANCELED


### PR DESCRIPTION
## Summary

This implements the remaining immediate Stage 0 execution-correctness mitigations from the validation execution integrity program:

- preserve provider-neutral `ExecutionStatus` through backend status responses, including `FAILED` with no diagnostic text
- reconcile explicit provider state instead of inferring success/failure from an optional message
- map Cloud Run cancellation separately from failure and call the supported `executions.cancel` operation rather than deleting the execution record
- fence user cancellation in PostgreSQL before requesting best-effort provider cancellation
- align runner, watchdog, and GCP validator Job deadlines on `VALIDATOR_TIMEOUT_SECONDS` (default 3600 seconds)
- time out and cancel provider work still running beyond that outer deadline instead of skipping it forever
- acknowledge late callbacks without reading storage or mutating terminal runs
- use an optimistic compare-and-set for callback finalization so a stale callback cannot overwrite concurrent cancellation or timeout
- preserve established duplicate-callback/idempotent replay responses
- emit finalization signals from cancellation, watchdog timeout, and reconciled provider failure paths

## Root causes

Several legacy paths collapsed provider state into `is_complete` plus optional human-readable error text. A Cloud Run `FAILED` condition with an empty message therefore looked like successful completion and could enter synthetic callback recovery.

Cancellation changed only the database run status, while the Cloud Run runner called execution deletion rather than the distinct cancellation operation. The watchdog used a fixed 30-minute threshold despite a 60-minute provider budget, then skipped executions that still reported RUNNING. Callback finalization used a stale model save that could overwrite a terminal decision made concurrently.

## Design notes

The hotfix deliberately avoids holding database locks across storage or provider calls. Logical cancellation/timeout is committed first; provider cancellation happens afterward. Callback finalization uses a conditional active-state update. The new `ExecutionResponse.execution_status` field is appended to preserve any legacy positional constructor use and defaults to `None` for reader-first compatibility.

Provider cancellation remains best-effort until the accepted execution-attempt lifecycle adds durable cancellation work and retries.

Cloud Run's cancellation endpoint is documented at https://docs.cloud.google.com/run/docs/reference/rest/v2/projects.locations.jobs.executions/cancel.

## Verification

- complete community suite: **4,459 passed, 32 skipped, 68 subtests passed**
- integrated callback/cancellation/reconciliation/launch-view group: **109 passed**
- final execution compatibility/lifecycle group: **80 passed**
- Django system check: no issues
- `makemigrations --check --dry-run`: no changes detected
- Ruff check and format: passed
- developer documentation build: passed
- GCP just module parses successfully
- all pre-commit hooks passed

## Companion change

[Validibot Cloud #3](https://github.com/danielmcquillen/validibot-cloud/pull/3) aligns compute-reservation reaping with the same runtime deadline so overdraft protection remains active for legitimate long-running validations.