### PR TITLE
Complete minimal execution attempt lifecycle

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -17,6 +17,7 @@ from pathlib import Path
 
 import environ
 from csp.constants import NONCE
+from django.core.exceptions import ImproperlyConfigured
 from django.utils.translation import gettext_lazy as _
 
 logger = logging.getLogger(__name__)
@@ -54,6 +55,14 @@ DEBUG = env.bool("DJANGO_DEBUG", False)
 #
 # If not set, auto-detection is used based on other settings.
 DEPLOYMENT_TARGET = env("DEPLOYMENT_TARGET", default=None)
+
+# Immutable execution semantics recorded on each new ValidationRun. The
+# attempt lifecycle is implemented as an opt-in rollout; existing deployments
+# remain on LEGACY until every web/worker instance has the reader release.
+VALIDATION_RUNTIME_PROFILE = env(
+    "VALIDATION_RUNTIME_PROFILE",
+    default="LEGACY",
+)
 
 # App role (web vs worker). Worker instances expose internal APIs only.
 # Default to "web" for local development; production sets APP_ROLE explicitly.
@@ -1144,6 +1153,23 @@ SIGNING_KEY_PATH = env("SIGNING_KEY_PATH", default="")
 GCP_KMS_SIGNING_KEY = env("GCP_KMS_SIGNING_KEY", default="")
 SIGNING_ALGORITHM = env("SIGNING_ALGORITHM", default="ES256")
 CLOUD_TASKS_SERVICE_ACCOUNT = env("CLOUD_TASKS_SERVICE_ACCOUNT", default="")
+# HTTP delivery is only the short Django orchestration request; validator
+# compute runs separately. Keep this comfortably below Cloud Tasks' 30-minute
+# maximum so a wedged worker is retried promptly.
+CLOUD_TASKS_DISPATCH_DEADLINE_SECONDS = env.int(
+    "CLOUD_TASKS_DISPATCH_DEADLINE_SECONDS",
+    default=10 * 60,
+)
+_CLOUD_TASKS_MIN_DEADLINE_SECONDS = 15
+_CLOUD_TASKS_MAX_DEADLINE_SECONDS = 30 * 60
+if not (
+    _CLOUD_TASKS_MIN_DEADLINE_SECONDS
+    <= CLOUD_TASKS_DISPATCH_DEADLINE_SECONDS
+    <= _CLOUD_TASKS_MAX_DEADLINE_SECONDS
+):
+    raise ImproperlyConfigured(
+        "CLOUD_TASKS_DISPATCH_DEADLINE_SECONDS must be between 15 and 1800."
+    )
 
 # Shared secret for authenticating requests to worker-only API endpoints.
 # Required for Docker Compose deployments (all services share the same key).
@@ -1468,3 +1494,18 @@ CELERY_TASK_ACKS_LATE = True
 
 # Reject on worker lost - requeue task if worker dies unexpectedly
 CELERY_TASK_REJECT_ON_WORKER_LOST = True
+
+# Redis restores an unacknowledged Celery message after this visibility
+# window. It must exceed the hard task limit or a healthy long validation can
+# be delivered to a second worker while the first is still running.
+CELERY_VISIBILITY_TIMEOUT_SECONDS = env.int(
+    "CELERY_VISIBILITY_TIMEOUT_SECONDS",
+    default=60 * 60,
+)
+CELERY_BROKER_TRANSPORT_OPTIONS = {
+    "visibility_timeout": CELERY_VISIBILITY_TIMEOUT_SECONDS,
+}
+if CELERY_VISIBILITY_TIMEOUT_SECONDS <= CELERY_TASK_TIME_LIMIT:
+    raise ImproperlyConfigured(
+        "CELERY_VISIBILITY_TIMEOUT_SECONDS must exceed CELERY_TASK_TIME_LIMIT."
+    )

--- a/docs/dev_docs/deployment/environment-configuration.md
+++ b/docs/dev_docs/deployment/environment-configuration.md
@@ -449,6 +449,21 @@ and the resolved audience or allowlist (after applying fallbacks) is
 empty. Misconfiguration surfaces in the deploy log, not in production
 traffic.
 
+### Task delivery bounds
+
+Validibot treats both supported task transports as at-least-once delivery.
+PostgreSQL run/attempt state provides idempotency; these settings bound how
+quickly the transport decides a delivery was lost:
+
+| Setting | Default | Deployment | Purpose |
+|---|---:|---|---|
+| `CELERY_VISIBILITY_TIMEOUT_SECONDS` | `3600` | Self-hosted Redis | Must exceed `CELERY_TASK_TIME_LIMIT` (1800 seconds), otherwise Redis can deliver a healthy long task to another worker. |
+| `CLOUD_TASKS_DISPATCH_DEADLINE_SECONDS` | `600` | GCP | Bounds the short worker HTTP orchestration request; accepted range is 15–1800 seconds. Validator compute runs separately in Cloud Run Jobs. |
+| `VALIDATION_RUNTIME_PROFILE` | `LEGACY` | All | Selects immutable semantics for newly created runs. Enable `ATTEMPT_LIFECYCLE_V1` only after all web/worker instances have the compatible release. |
+
+Transport retries never authorize a second provider launch after an attempt
+has reached `DISPATCHING`, `RUNNING`, or `UNKNOWN`.
+
 **Audience contract.** Cloud Tasks and Cloud Scheduler sign tokens
 with `aud = <service URL origin>` — path and query are NOT included.
 Django's strict verification enforces exact match. Validator

--- a/docs/operations/self-hosting/configuration.md
+++ b/docs/operations/self-hosting/configuration.md
@@ -83,6 +83,8 @@ The doctor command's VB001-VB099 range checks these.
 | `VALIDATOR_BACKEND_IMAGE_POLICY` | `tag` (default), `digest`, or `signed-digest` (Phase 5). Production: `digest` or higher. Enforced at launch — only enable `digest` once validator images are digest-pinned, or launches fail. |
 | `VALIDATOR_RETAIN_HOURS` | How long stopped validator containers are kept before `cleanup` removes them. Default: `24`. |
 | `VALIDATOR_TIMEOUT_SECONDS` | Outer per-validator timeout and stuck-run watchdog deadline. Validators can request shorter via their manifest. |
+| `CELERY_VISIBILITY_TIMEOUT_SECONDS` | Redis redelivery window. Default: `3600`; it must remain greater than Celery's 30-minute hard task limit so a healthy long task is not delivered twice. |
+| `VALIDATION_RUNTIME_PROFILE` | Immutable semantics for newly created runs. Keep the default `LEGACY` during mixed-version deployment; use `ATTEMPT_LIFECYCLE_V1` only after every web and worker instance has the lifecycle writer release. |
 
 ### 7. Pro and signing
 

--- a/validibot/core/tasks/dispatch/google_cloud_tasks.py
+++ b/validibot/core/tasks/dispatch/google_cloud_tasks.py
@@ -11,12 +11,16 @@ import json
 import logging
 
 from django.conf import settings
+from google.protobuf import duration_pb2
 
 from validibot.core.tasks.dispatch.base import TaskDispatcher
 from validibot.core.tasks.dispatch.base import TaskDispatchRequest
 from validibot.core.tasks.dispatch.base import TaskDispatchResponse
 
 logger = logging.getLogger(__name__)
+
+MIN_DISPATCH_DEADLINE_SECONDS = 15
+MAX_DISPATCH_DEADLINE_SECONDS = 30 * 60
 
 
 class GoogleCloudTasksDispatcher(TaskDispatcher):
@@ -131,6 +135,9 @@ class GoogleCloudTasksDispatcher(TaskDispatcher):
                     audience=worker_url,
                 ),
             ),
+            dispatch_deadline=duration_pb2.Duration(
+                seconds=self._get_dispatch_deadline_seconds()
+            ),
         )
 
         create_request = tasks_v2.CreateTaskRequest(
@@ -186,3 +193,16 @@ class GoogleCloudTasksDispatcher(TaskDispatcher):
                 "(e.g. validibot-cloudrun-prod@PROJECT.iam.gserviceaccount.com).",
             )
         return service_account
+
+    @staticmethod
+    def _get_dispatch_deadline_seconds() -> int:
+        """Return a valid Cloud Tasks HTTP deadline for orchestration work."""
+        deadline = int(getattr(settings, "CLOUD_TASKS_DISPATCH_DEADLINE_SECONDS", 600))
+        if not (
+            MIN_DISPATCH_DEADLINE_SECONDS <= deadline <= MAX_DISPATCH_DEADLINE_SECONDS
+        ):
+            raise ValueError(
+                "CLOUD_TASKS_DISPATCH_DEADLINE_SECONDS must be between "
+                "15 and 1800 seconds."
+            )
+        return deadline

--- a/validibot/core/tests/test_cloud_tasks_dispatcher.py
+++ b/validibot/core/tests/test_cloud_tasks_dispatcher.py
@@ -1,11 +1,16 @@
-"""
-Tests for GoogleCloudTasksDispatcher service account configuration.
+"""Tests for security and delivery bounds in the Cloud Tasks dispatcher.
+
+Cloud Tasks authenticates the worker request with an explicit service account
+and must stop waiting well before its platform maximum. These tests keep both
+configuration failures visible rather than relying on provider defaults.
 """
 
 import pytest
 from django.test.utils import override_settings
 
 from validibot.core.tasks.dispatch.google_cloud_tasks import GoogleCloudTasksDispatcher
+
+TEST_DISPATCH_DEADLINE_SECONDS = 420
 
 
 def test_get_invoker_service_account_uses_explicit_setting():
@@ -30,3 +35,24 @@ def test_get_invoker_service_account_requires_setting():
         ),
     ):
         dispatcher._get_invoker_service_account()
+
+
+def test_dispatch_deadline_uses_explicit_setting():
+    """Deployments may tune the short HTTP orchestration request deliberately."""
+    with override_settings(
+        CLOUD_TASKS_DISPATCH_DEADLINE_SECONDS=TEST_DISPATCH_DEADLINE_SECONDS
+    ):
+        assert (
+            GoogleCloudTasksDispatcher._get_dispatch_deadline_seconds()
+            == TEST_DISPATCH_DEADLINE_SECONDS
+        )
+
+
+@pytest.mark.parametrize("deadline", [14, 1801])
+def test_dispatch_deadline_rejects_values_outside_cloud_tasks_bounds(deadline):
+    """Invalid queue settings should fail locally instead of during delivery."""
+    with (
+        override_settings(CLOUD_TASKS_DISPATCH_DEADLINE_SECONDS=deadline),
+        pytest.raises(ValueError, match="between 15 and 1800"),
+    ):
+        GoogleCloudTasksDispatcher._get_dispatch_deadline_seconds()

--- a/validibot/core/tests/test_task_delivery_settings.py
+++ b/validibot/core/tests/test_task_delivery_settings.py
@@ -1,0 +1,29 @@
+"""Tests for cross-deployment task delivery safety bounds.
+
+Self-hosted Redis visibility must outlast a legitimate Celery task or it can
+redeliver work while the first worker still runs. GCP HTTP delivery should be
+short because it only orchestrates Cloud Run work, not performs validator
+compute. These assertions keep those operational assumptions explicit.
+"""
+
+from django.conf import settings
+
+MIN_CLOUD_TASKS_DEADLINE_SECONDS = 15
+MAX_CLOUD_TASKS_DEADLINE_SECONDS = 30 * 60
+
+
+def test_redis_visibility_exceeds_celery_hard_task_limit():
+    """A healthy long task must not become visible to a second worker."""
+    assert (
+        settings.CELERY_BROKER_TRANSPORT_OPTIONS["visibility_timeout"]
+        > settings.CELERY_TASK_TIME_LIMIT
+    )
+
+
+def test_cloud_tasks_deadline_is_bounded_for_short_orchestration():
+    """Cloud Tasks should retry a wedged worker before its platform maximum."""
+    assert (
+        MIN_CLOUD_TASKS_DEADLINE_SECONDS
+        <= settings.CLOUD_TASKS_DISPATCH_DEADLINE_SECONDS
+        <= MAX_CLOUD_TASKS_DEADLINE_SECONDS
+    )

--- a/validibot/validations/management/commands/cleanup_stuck_runs.py
+++ b/validibot/validations/management/commands/cleanup_stuck_runs.py
@@ -53,6 +53,7 @@ from validibot.validations.services.runtime_profiles import (
 )
 from validibot.validations.services.runtime_profiles import is_runtime_profile_supported
 from validibot.validations.services.validation_run import cancel_active_execution
+from validibot.validations.services.validation_run import fence_active_execution_attempt
 
 logger = logging.getLogger(__name__)
 
@@ -193,6 +194,14 @@ class Command(BaseCommand):
                         "duration_ms",
                     ]
                 )
+                from validibot.validations.constants import ExecutionAttemptState
+
+                fence_active_execution_attempt(
+                    locked,
+                    target=ExecutionAttemptState.TIMED_OUT,
+                    error_code="run_timed_out",
+                    error_message=error_message,
+                )
                 timed_out_ids.append(str(locked.id))
 
                 workflow_id = locked.workflow_id
@@ -292,8 +301,11 @@ class Command(BaseCommand):
             - "not_applicable": Not a GCP run or missing metadata
             - "error": GCP API call failed (fall through to timeout)
         """
-        legacy_profiles = (ValidationRuntimeProfile.LEGACY,)
-        if not is_runtime_profile_supported(run.runtime_profile, legacy_profiles):
+        supported_profiles = (
+            ValidationRuntimeProfile.LEGACY,
+            ValidationRuntimeProfile.ATTEMPT_LIFECYCLE_V1,
+        )
+        if not is_runtime_profile_supported(run.runtime_profile, supported_profiles):
             if dry_run:
                 self.stdout.write(
                     f"  [PROFILE-REJECT] {run.id}: runtime profile "
@@ -302,7 +314,7 @@ class Command(BaseCommand):
             else:
                 ensure_runtime_profile_supported(
                     run,
-                    supported_profiles=legacy_profiles,
+                    supported_profiles=supported_profiles,
                     operation="cleanup_stuck_runs",
                     sender=self.__class__,
                 )
@@ -317,10 +329,15 @@ class Command(BaseCommand):
         if not step_run:
             return "not_applicable"
 
-        step_output = step_run.output or {}
-        execution_name = step_output.get("execution_name")
-        if not execution_name:
+        from validibot.validations.services.execution_attempts import (
+            resolve_provider_execution_identity,
+        )
+
+        identity = resolve_provider_execution_identity(step_run)
+        if identity is None:
             return "not_applicable"
+        execution_name = identity.execution_id
+        step_output = step_run.output or {}
 
         # 3. Query Cloud Run Job status via backend
         try:
@@ -384,7 +401,13 @@ class Command(BaseCommand):
             )
             return "reconciled"
 
-        return self._recover_lost_callback(run, step_run, step_output)
+        return self._recover_lost_callback(
+            run,
+            step_run,
+            step_output,
+            execution_bundle_uri=identity.execution_bundle_uri,
+            attempt=identity.attempt,
+        )
 
     def _is_gcp_deployment(self) -> bool:
         """Check if the current deployment target is GCP."""
@@ -417,6 +440,20 @@ class Command(BaseCommand):
     ) -> None:
         """Mark a run as failed based on GCP Cloud Run Job failure."""
         error_message = error_message or PROVIDER_FAILURE_WITHOUT_DETAILS
+        attempt = None
+        from validibot.validations.services.runtime_profiles import (
+            get_runtime_profile_policy,
+        )
+
+        if get_runtime_profile_policy(run.runtime_profile).uses_execution_attempts:
+            step_run = self._get_active_step_run(run)
+            from validibot.validations.services.execution_attempts import (
+                get_active_execution_attempt,
+            )
+
+            if step_run is not None:
+                attempt = get_active_execution_attempt(step_run)
+
         with transaction.atomic():
             locked = ValidationRun.objects.select_for_update().get(pk=run.pk)
             if locked.status != ValidationRunStatus.RUNNING:
@@ -454,6 +491,20 @@ class Command(BaseCommand):
                 },
             )
 
+        if attempt is not None:
+            from validibot.validations.constants import ExecutionAttemptState
+            from validibot.validations.services.execution_attempts import (
+                transition_execution_attempt,
+            )
+
+            transition_execution_attempt(
+                attempt.pk,
+                ExecutionAttemptState.FAILED,
+                provider_finished_at=timezone.now(),
+                last_error_code="provider_failed",
+                last_error=error_message,
+            )
+
         from validibot.validations.signals import validation_run_finalized
 
         validation_run_finalized.send_robust(
@@ -466,6 +517,9 @@ class Command(BaseCommand):
         run: ValidationRun,
         step_run: ValidationStepRun,
         step_output: dict,
+        *,
+        execution_bundle_uri: str = "",
+        attempt=None,
     ) -> str:
         """
         Recover a completed GCP run by processing a synthetic callback.
@@ -486,7 +540,9 @@ class Command(BaseCommand):
         Returns:
             "reconciled" on success, "error" on failure.
         """
-        execution_bundle_uri = step_output.get("execution_bundle_uri", "")
+        execution_bundle_uri = execution_bundle_uri or step_output.get(
+            "execution_bundle_uri", ""
+        )
         if not execution_bundle_uri:
             logger.warning(
                 "Cannot recover run %s: no execution_bundle_uri in step output",
@@ -500,9 +556,17 @@ class Command(BaseCommand):
         # Build a synthetic callback payload
         from validibot_shared.validations.envelopes import ValidationStatus
 
+        callback_id = f"reconciliation-{run.id}"
+        if attempt is not None:
+            from validibot.validations.services.execution_attempts import (
+                build_attempt_callback_id,
+            )
+
+            callback_id = build_attempt_callback_id(attempt)
+
         callback_payload = {
             "run_id": str(run.id),
-            "callback_id": f"reconciliation-{run.id}",
+            "callback_id": callback_id,
             "status": ValidationStatus.SUCCESS,
             "result_uri": result_uri,
         }

--- a/validibot/validations/services/cloud_run/launcher.py
+++ b/validibot/validations/services/cloud_run/launcher.py
@@ -26,6 +26,7 @@ import os
 from typing import TYPE_CHECKING
 
 from django.conf import settings
+from django.utils import timezone
 
 from validibot.validations.constants import CloudRunJobStatus
 from validibot.validations.constants import Severity
@@ -196,6 +197,142 @@ def _mark_step_run_running(step_run, *, image_digest: str | None = None) -> None
     step_run.save(update_fields=update_fields)
 
 
+class ProviderDispatchAmbiguousError(RuntimeError):
+    """The provider call may have been accepted but returned no identity."""
+
+
+def _callback_id_for_step(step_run) -> str:
+    """Bind attempt-mode callbacks to one launch, retaining legacy ids."""
+    from validibot.validations.services.execution_attempts import (
+        build_attempt_callback_id,
+    )
+    from validibot.validations.services.execution_attempts import (
+        get_active_execution_attempt,
+    )
+
+    attempt = get_active_execution_attempt(step_run)
+    if attempt is not None:
+        return build_attempt_callback_id(attempt)
+    return f"step-run-{step_run.id}"
+
+
+def _run_validator_job_safely(
+    *,
+    step_run,
+    project_id: str,
+    region: str,
+    job_name: str,
+    input_uri: str,
+    execution_bundle_uri: str,
+) -> str:
+    """Launch once and preserve provider-acceptance ambiguity explicitly.
+
+    Legacy runs retain their existing direct call. Attempt-mode runs claim the
+    durable row immediately before the external API. If the call raises, the
+    attempt becomes UNKNOWN and no delivery is allowed to launch it again.
+    """
+    from validibot.validations.constants import ExecutionAttemptState
+    from validibot.validations.services.execution_attempts import (
+        get_active_execution_attempt,
+    )
+    from validibot.validations.services.execution_attempts import (
+        transition_execution_attempt,
+    )
+
+    attempt = get_active_execution_attempt(step_run)
+    if attempt is None:
+        return run_validator_job(
+            project_id=project_id,
+            region=region,
+            job_name=job_name,
+            input_uri=input_uri,
+        )
+
+    if attempt.state != ExecutionAttemptState.PENDING:
+        if attempt.state == ExecutionAttemptState.RUNNING and (
+            attempt.provider_execution_id
+        ):
+            return attempt.provider_execution_id
+        raise ProviderDispatchAmbiguousError(
+            f"Execution attempt {attempt.pk} was already claimed"
+        )
+
+    attempt, claimed = transition_execution_attempt(
+        attempt.pk,
+        ExecutionAttemptState.DISPATCHING,
+        provider_job_name=job_name,
+        execution_bundle_uri=execution_bundle_uri,
+        input_envelope_uri=input_uri,
+    )
+    if not claimed:
+        if attempt.state == ExecutionAttemptState.RUNNING and (
+            attempt.provider_execution_id
+        ):
+            return attempt.provider_execution_id
+        raise ProviderDispatchAmbiguousError(
+            f"Execution attempt {attempt.pk} was already claimed"
+        )
+
+    try:
+        execution_name = run_validator_job(
+            project_id=project_id,
+            region=region,
+            job_name=job_name,
+            input_uri=input_uri,
+        )
+    except Exception as exc:
+        transition_execution_attempt(
+            attempt.pk,
+            ExecutionAttemptState.UNKNOWN,
+            last_error_code="provider_acceptance_unknown",
+            last_error="Provider dispatch raised before returning execution identity.",
+        )
+        raise ProviderDispatchAmbiguousError(
+            f"Provider acceptance is unknown for execution attempt {attempt.pk}"
+        ) from exc
+
+    transition_execution_attempt(
+        attempt.pk,
+        ExecutionAttemptState.RUNNING,
+        provider_execution_id=execution_name,
+        provider_started_at=timezone.now(),
+    )
+    return execution_name
+
+
+def _ambiguous_dispatch_result() -> ValidationResult:
+    """Keep the workflow pending until reconciliation or operator action."""
+    return ValidationResult(
+        passed=None,
+        issues=[],
+        stats={
+            "job_status": CloudRunJobStatus.PENDING,
+            "dispatch_state": "UNKNOWN",
+        },
+    )
+
+
+def _attempt_requires_reconciliation(step_run) -> bool:
+    """Return whether provider work was claimed before a later local error."""
+    if step_run is None:
+        return False
+    from validibot.validations.constants import ExecutionAttemptState
+    from validibot.validations.services.execution_attempts import (
+        get_active_execution_attempt,
+    )
+
+    attempt = get_active_execution_attempt(step_run)
+    return bool(
+        attempt
+        and attempt.state
+        in {
+            ExecutionAttemptState.DISPATCHING,
+            ExecutionAttemptState.RUNNING,
+            ExecutionAttemptState.UNKNOWN,
+        }
+    )
+
+
 def launch_energyplus_validation(
     *,
     run: ValidationRun,
@@ -234,6 +371,7 @@ def launch_energyplus_validation(
         ValueError: If required config is missing (e.g., weather_file)
         Exception: If GCS upload or job trigger fails
     """
+    current_step_run = None
     try:
         # 0. Idempotency check
         current_step_run = run.current_step_run
@@ -274,7 +412,7 @@ def launch_energyplus_validation(
 
         # 3. Build callback URL and idempotency key
         callback_url = build_validation_callback_url()
-        callback_id = f"step-run-{current_step_run.id}"
+        callback_id = _callback_id_for_step(current_step_run)
 
         # 4. Build typed input envelope
         step_config = step.config or {}
@@ -368,11 +506,13 @@ def launch_energyplus_validation(
                 raise RuntimeError(msg)  # noqa: TRY301
 
         logger.info("Triggering Cloud Run Job: %s", job_name)
-        execution_name = run_validator_job(
+        execution_name = _run_validator_job_safely(
+            step_run=current_step_run,
             project_id=settings.GCP_PROJECT_ID,
             region=settings.GCP_REGION,
             job_name=job_name,
             input_uri=input_envelope_uri,
+            execution_bundle_uri=execution_bundle_uri,
         )
 
         # 6.5. Resolve validator backend image digest from the
@@ -406,7 +546,20 @@ def launch_energyplus_validation(
             stats=stats,
         )
 
+    except ProviderDispatchAmbiguousError:
+        logger.warning(
+            "Cloud Run acceptance is unknown for EnergyPlus run %s; "
+            "waiting for reconciliation or callback",
+            run.id,
+        )
+        return _ambiguous_dispatch_result()
     except Exception:
+        if _attempt_requires_reconciliation(current_step_run):
+            logger.exception(
+                "EnergyPlus launch follow-up failed after provider claim; "
+                "preserving attempt for reconciliation"
+            )
+            return _ambiguous_dispatch_result()
         logger.exception("Failed to launch EnergyPlus Cloud Run Job for run %s", run.id)
         issues = [
             ValidationIssue(
@@ -436,6 +589,7 @@ def launch_fmu_validation(
     an FMU input envelope, uploads it, triggers the Cloud Run Job, and returns
     a pending ValidationResult.
     """
+    current_step_run = None
     try:
         # 0. Idempotency check
         current_step_run = run.current_step_run
@@ -474,7 +628,7 @@ def launch_fmu_validation(
         # allowing the callback receipt fencing to correctly identify and handle
         # duplicate callbacks. Note: Job launch idempotency is handled by the
         # check at step 0 above (checking step_run.output for existing job_name).
-        callback_id = f"step-run-{current_step_run.id}"
+        callback_id = _callback_id_for_step(current_step_run)
 
         # Build envelope via the shared builder. This gets signal-aware
         # input resolution (StepInputBinding + resolve_path), proper
@@ -543,11 +697,13 @@ def launch_fmu_validation(
                 )
                 raise RuntimeError(msg)  # noqa: TRY301
 
-        execution_name = run_validator_job(
+        execution_name = _run_validator_job_safely(
+            step_run=current_step_run,
             project_id=settings.GCP_PROJECT_ID,
             region=settings.GCP_REGION,
             job_name=job_name,
             input_uri=input_envelope_uri,
+            execution_bundle_uri=execution_bundle_uri,
         )
 
         # Resolve validator backend image digest from the Execution's
@@ -574,7 +730,20 @@ def launch_fmu_validation(
         }
         return ValidationResult(passed=None, issues=[], stats=stats)
 
+    except ProviderDispatchAmbiguousError:
+        logger.warning(
+            "Cloud Run acceptance is unknown for FMU run %s; "
+            "waiting for reconciliation or callback",
+            run.id,
+        )
+        return _ambiguous_dispatch_result()
     except Exception:
+        if _attempt_requires_reconciliation(current_step_run):
+            logger.exception(
+                "FMU launch follow-up failed after provider claim; "
+                "preserving attempt for reconciliation"
+            )
+            return _ambiguous_dispatch_result()
         logger.exception("Failed to launch FMU Cloud Run Job for run %s", run.id)
         issues = [
             ValidationIssue(
@@ -605,6 +774,7 @@ def launch_shacl_validation(
     (which resolves shapes/ontology/settings/SPARQL-ASK assertions from the DB),
     triggers the Cloud Run Job, and returns a pending ValidationResult.
     """
+    current_step_run = None
     try:
         # 0. Idempotency check.
         current_step_run = run.current_step_run
@@ -656,7 +826,7 @@ def launch_shacl_validation(
 
         # 2. Callback + idempotency key.
         callback_url = build_validation_callback_url()
-        callback_id = f"step-run-{current_step_run.id}"
+        callback_id = _callback_id_for_step(current_step_run)
 
         # 3. Build the typed envelope via the shared builder (SHACL branch reads
         # primary_file_uri from input_file_uris and resolves rulesets/assertions).
@@ -718,11 +888,13 @@ def launch_shacl_validation(
                 )
                 raise RuntimeError(msg)  # noqa: TRY301
 
-        execution_name = run_validator_job(
+        execution_name = _run_validator_job_safely(
+            step_run=current_step_run,
             project_id=settings.GCP_PROJECT_ID,
             region=settings.GCP_REGION,
             job_name=job_name,
             input_uri=input_envelope_uri,
+            execution_bundle_uri=execution_bundle_uri,
         )
 
         backend_image_digest = get_execution_image_digest(execution_name)
@@ -738,7 +910,20 @@ def launch_shacl_validation(
         }
         return ValidationResult(passed=None, issues=[], stats=stats)
 
+    except ProviderDispatchAmbiguousError:
+        logger.warning(
+            "Cloud Run acceptance is unknown for SHACL run %s; "
+            "waiting for reconciliation or callback",
+            run.id,
+        )
+        return _ambiguous_dispatch_result()
     except Exception:
+        if _attempt_requires_reconciliation(current_step_run):
+            logger.exception(
+                "SHACL launch follow-up failed after provider claim; "
+                "preserving attempt for reconciliation"
+            )
+            return _ambiguous_dispatch_result()
         logger.exception("Failed to launch SHACL Cloud Run Job for run %s", run.id)
         issues = [
             ValidationIssue(
@@ -779,6 +964,7 @@ def launch_schematron_validation(
     )
     from validibot.validations.validators.schematron.validator import CODE_RULES_INVALID
 
+    current_step_run = None
     try:
         # 0. Idempotency check.
         current_step_run = run.current_step_run
@@ -830,7 +1016,7 @@ def launch_schematron_validation(
 
         # 2. Callback + idempotency key.
         callback_url = build_validation_callback_url()
-        callback_id = f"step-run-{current_step_run.id}"
+        callback_id = _callback_id_for_step(current_step_run)
 
         # 3. Build the typed envelope via the shared builder (the SCHEMATRON
         # branch resolves the rules text from the step's ruleset and ships
@@ -892,11 +1078,13 @@ def launch_schematron_validation(
                 )
                 raise RuntimeError(msg)  # noqa: TRY301
 
-        execution_name = run_validator_job(
+        execution_name = _run_validator_job_safely(
+            step_run=current_step_run,
             project_id=settings.GCP_PROJECT_ID,
             region=settings.GCP_REGION,
             job_name=job_name,
             input_uri=input_envelope_uri,
+            execution_bundle_uri=execution_bundle_uri,
         )
 
         backend_image_digest = get_execution_image_digest(execution_name)
@@ -915,6 +1103,13 @@ def launch_schematron_validation(
         }
         return ValidationResult(passed=None, issues=[], stats=stats)
 
+    except ProviderDispatchAmbiguousError:
+        logger.warning(
+            "Cloud Run acceptance is unknown for Schematron run %s; "
+            "waiting for reconciliation or callback",
+            run.id,
+        )
+        return _ambiguous_dispatch_result()
     except SchematronRulesResolutionError as exc:
         # D9: a step with no resolvable rules is an authoring problem — the
         # rules were never run, and this must not read as "your document
@@ -934,6 +1129,12 @@ def launch_schematron_validation(
         ]
         return ValidationResult(passed=False, issues=issues, stats={})
     except Exception:
+        if _attempt_requires_reconciliation(current_step_run):
+            logger.exception(
+                "Schematron launch follow-up failed after provider claim; "
+                "preserving attempt for reconciliation"
+            )
+            return _ambiguous_dispatch_result()
         logger.exception(
             "Failed to launch Schematron Cloud Run Job for run %s",
             run.id,

--- a/validibot/validations/services/execution/docker_compose.py
+++ b/validibot/validations/services/execution/docker_compose.py
@@ -38,6 +38,7 @@ import uuid
 from typing import TYPE_CHECKING
 
 from django.conf import settings
+from django.utils import timezone
 
 from validibot.core.storage import get_data_storage
 from validibot.validations.services.execution.base import ExecutionBackend
@@ -223,6 +224,19 @@ class DockerComposeExecutionBackend(ExecutionBackend):
             )
 
         execution_id = str(uuid.uuid4())[:12]
+        from validibot.validations.constants import ExecutionAttemptState
+        from validibot.validations.services.execution_attempts import (
+            build_attempt_callback_id,
+        )
+        from validibot.validations.services.execution_attempts import (
+            get_active_execution_attempt,
+        )
+        from validibot.validations.services.execution_attempts import (
+            transition_execution_attempt,
+        )
+
+        step_run = request.run.current_step_run
+        attempt = get_active_execution_attempt(step_run) if step_run else None
 
         try:
             # 1. Build the per-run workspace and the envelope override
@@ -234,7 +248,11 @@ class DockerComposeExecutionBackend(ExecutionBackend):
             # 2. Build callback URL and ID (unused for sync, but the
             # envelope schema still requires the fields).
             callback_url = self._get_callback_url()
-            callback_id = f"step-run-{request.run.current_step_run.id}"
+            callback_id = (
+                build_attempt_callback_id(attempt)
+                if attempt is not None
+                else f"step-run-{request.run.current_step_run.id}"
+            )
 
             # 3. Build the envelope with container-visible URIs.
             envelope = self.build_input_envelope(
@@ -260,6 +278,20 @@ class DockerComposeExecutionBackend(ExecutionBackend):
                 request.run_id,
                 workspace.host_input_envelope_path,
             )
+
+            if attempt is not None:
+                attempt, claimed = transition_execution_attempt(
+                    attempt.pk,
+                    ExecutionAttemptState.DISPATCHING,
+                    execution_bundle_uri=workspace.execution_bundle_container_uri,
+                    input_envelope_uri=workspace.input_envelope_container_uri,
+                )
+                if not claimed:
+                    return ExecutionResponse(
+                        execution_id=attempt.provider_execution_id,
+                        is_complete=False,
+                        execution_bundle_uri=attempt.execution_bundle_uri,
+                    )
 
             # 5. Resolve container image.
             container_image = self.get_container_image(request.validator_type)
@@ -309,6 +341,16 @@ class DockerComposeExecutionBackend(ExecutionBackend):
                     result.exit_code,
                     error_msg,
                 )
+                if attempt is not None:
+                    transition_execution_attempt(
+                        attempt.pk,
+                        ExecutionAttemptState.FAILED,
+                        provider_execution_id=result.execution_id or execution_id,
+                        provider_finished_at=timezone.now(),
+                        last_error_code="container_execution_failed",
+                        last_error=error_msg,
+                        backend_image_digest=result.validator_backend_image_digest,
+                    )
                 return ExecutionResponse(
                     execution_id=result.execution_id or execution_id,
                     is_complete=True,
@@ -326,6 +368,15 @@ class DockerComposeExecutionBackend(ExecutionBackend):
             output_envelope = self._read_output_envelope_from_host(
                 workspace.host_output_envelope_path,
             )
+
+            if attempt is not None:
+                transition_execution_attempt(
+                    attempt.pk,
+                    ExecutionAttemptState.COMPLETED,
+                    provider_execution_id=result.execution_id or execution_id,
+                    provider_finished_at=timezone.now(),
+                    backend_image_digest=result.validator_backend_image_digest,
+                )
 
             logger.info(
                 "Container execution completed for run %s in %.2fs",
@@ -346,6 +397,14 @@ class DockerComposeExecutionBackend(ExecutionBackend):
 
         except TimeoutError as e:
             logger.exception("Container execution timed out for run %s", request.run_id)
+            if attempt is not None:
+                transition_execution_attempt(
+                    attempt.pk,
+                    ExecutionAttemptState.TIMED_OUT,
+                    provider_finished_at=timezone.now(),
+                    last_error_code="container_timeout",
+                    last_error=str(e),
+                )
             return ExecutionResponse(
                 execution_id=execution_id,
                 is_complete=True,
@@ -354,10 +413,30 @@ class DockerComposeExecutionBackend(ExecutionBackend):
 
         except Exception as e:
             logger.exception("Failed to execute validation for run %s", request.run_id)
+            dispatch_is_ambiguous = False
+            if attempt is not None:
+                attempt.refresh_from_db(fields=["state"])
+                if attempt.state == ExecutionAttemptState.DISPATCHING:
+                    transition_execution_attempt(
+                        attempt.pk,
+                        ExecutionAttemptState.UNKNOWN,
+                        last_error_code="container_state_unknown",
+                        last_error=str(e),
+                    )
+                    dispatch_is_ambiguous = True
+                elif attempt.state == ExecutionAttemptState.PENDING:
+                    transition_execution_attempt(
+                        attempt.pk,
+                        ExecutionAttemptState.FAILED,
+                        last_error_code="container_preparation_failed",
+                        last_error=str(e),
+                    )
             return ExecutionResponse(
                 execution_id=execution_id,
-                is_complete=True,
-                error_message=f"Execution failed: {e}",
+                is_complete=not dispatch_is_ambiguous,
+                error_message=(
+                    None if dispatch_is_ambiguous else f"Execution failed: {e}"
+                ),
             )
 
     # ── Workspace dispatch helpers ──────────────────────────────────────

--- a/validibot/validations/services/execution_attempts.py
+++ b/validibot/validations/services/execution_attempts.py
@@ -11,8 +11,10 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
+from uuid import UUID
 
 from django.db import transaction
+from django.db.models import Max
 from django.utils import timezone
 
 from validibot.core.textsafety import sanitize_plain_text
@@ -24,7 +26,6 @@ from validibot.validations.services.runtime_profiles import get_runtime_profile_
 
 if TYPE_CHECKING:
     from datetime import datetime
-    from uuid import UUID
 
     from validibot.validations.models import ExecutionAttempt
     from validibot.validations.models import ValidationStepRun
@@ -46,10 +47,91 @@ class ProviderExecutionIdentity:
     attempt: ExecutionAttempt | None
 
 
+ATTEMPT_CALLBACK_PREFIX = "execution-attempt-"
+
+
+def build_attempt_callback_id(attempt: ExecutionAttempt) -> str:
+    """Return the opaque callback id that binds delivery to one attempt."""
+    return f"{ATTEMPT_CALLBACK_PREFIX}{attempt.pk}"
+
+
+def resolve_callback_attempt(
+    callback_id: str | None,
+    *,
+    run_id: UUID | str,
+) -> ExecutionAttempt | None:
+    """Resolve an attempt-mode callback without trusting its run identifier.
+
+    The callback id is an opaque idempotency key in the shared envelope
+    contract. Attempt-mode writers encode the attempt UUID in that key, while
+    this reader verifies the database relationship back to ``run_id``. Legacy
+    ``step-run-*`` callback ids intentionally return ``None``.
+    """
+    from validibot.validations.models import ExecutionAttempt
+
+    if not callback_id or not callback_id.startswith(ATTEMPT_CALLBACK_PREFIX):
+        return None
+    raw_attempt_id = callback_id.removeprefix(ATTEMPT_CALLBACK_PREFIX)
+    try:
+        attempt_id = UUID(raw_attempt_id)
+    except ValueError:
+        return None
+    return (
+        ExecutionAttempt.objects.select_related("step_run__validation_run")
+        .filter(pk=attempt_id, step_run__validation_run_id=run_id)
+        .first()
+    )
+
+
+def get_or_create_execution_attempt(
+    step_run: ValidationStepRun,
+    *,
+    runner_type: str,
+) -> tuple[ExecutionAttempt | None, bool]:
+    """Return the active attempt, creating it for an attempt-mode run.
+
+    Locking the logical step makes attempt-number allocation deterministic and
+    complements the partial unique constraint that permits only one active
+    attempt. Legacy runs return ``(None, False)`` so callers can keep their
+    established behavior during the compatibility window.
+    """
+    from validibot.validations.models import ExecutionAttempt
+    from validibot.validations.models import ValidationStepRun
+
+    with transaction.atomic():
+        locked_step = (
+            ValidationStepRun.objects.select_for_update()
+            .select_related("validation_run")
+            .get(pk=step_run.pk)
+        )
+        policy = get_runtime_profile_policy(locked_step.validation_run.runtime_profile)
+        if not policy.uses_execution_attempts:
+            return None, False
+
+        active = get_active_execution_attempt(locked_step, for_update=True)
+        if active is not None:
+            return active, False
+
+        last_number = (
+            locked_step.execution_attempts.aggregate(value=Max("attempt_number"))[
+                "value"
+            ]
+            or 0
+        )
+        attempt = ExecutionAttempt.objects.create(
+            step_run=locked_step,
+            attempt_number=last_number + 1,
+            runner_type=runner_type[:64],
+            contract_version=policy.contract_version,
+        )
+        return attempt, True
+
+
 _ALLOWED_TRANSITIONS = {
     ExecutionAttemptState.PENDING: frozenset(
         {
             ExecutionAttemptState.DISPATCHING,
+            ExecutionAttemptState.FAILED,
             ExecutionAttemptState.CANCELED,
         }
     ),
@@ -128,6 +210,11 @@ def resolve_provider_execution_identity(
     policy = get_runtime_profile_policy(step_run.validation_run.runtime_profile)
     if policy.uses_execution_attempts:
         attempt = get_active_execution_attempt(step_run)
+        if attempt is None:
+            # Terminal fencing deliberately happens before best-effort provider
+            # cancellation. Retain the latest attempt's provider address so
+            # the external cancel request can run after the DB commit.
+            attempt = step_run.execution_attempts.order_by("-attempt_number").first()
         if attempt is None or not attempt.provider_execution_id:
             return None
         return ProviderExecutionIdentity(
@@ -158,6 +245,11 @@ def transition_execution_attempt(
     last_error: str | None = None,
     provider_started_at: datetime | None = None,
     provider_finished_at: datetime | None = None,
+    provider_job_name: str | None = None,
+    provider_execution_id: str | None = None,
+    execution_bundle_uri: str | None = None,
+    input_envelope_uri: str | None = None,
+    backend_image_digest: str | None = None,
 ) -> tuple[ExecutionAttempt, bool]:
     """Lock and monotonically transition one attempt.
 
@@ -225,6 +317,25 @@ def transition_execution_attempt(
             ),
             "provider_started_at": provider_started_at,
             "provider_finished_at": provider_finished_at,
+            "provider_job_name": (
+                provider_job_name[:512] if provider_job_name is not None else None
+            ),
+            "provider_execution_id": (
+                provider_execution_id[:512]
+                if provider_execution_id is not None
+                else None
+            ),
+            "execution_bundle_uri": (
+                execution_bundle_uri[:2048]
+                if execution_bundle_uri is not None
+                else None
+            ),
+            "input_envelope_uri": (
+                input_envelope_uri[:2048] if input_envelope_uri is not None else None
+            ),
+            "backend_image_digest": (
+                backend_image_digest[:256] if backend_image_digest is not None else None
+            ),
         }
         for field_name, value in optional_updates.items():
             if value is not None:

--- a/validibot/validations/services/runtime_profiles.py
+++ b/validibot/validations/services/runtime_profiles.py
@@ -93,7 +93,12 @@ _PROFILE_POLICIES = {
 # Stage 1 is intentionally reader-first.  Later stages expand this set only
 # after every callback, task, watchdog, and reconciliation instance can handle
 # the next profile.
-WRITER_ENABLED_RUNTIME_PROFILES = frozenset({ValidationRuntimeProfile.LEGACY})
+WRITER_ENABLED_RUNTIME_PROFILES = frozenset(
+    {
+        ValidationRuntimeProfile.LEGACY,
+        ValidationRuntimeProfile.ATTEMPT_LIFECYCLE_V1,
+    }
+)
 
 
 def get_runtime_profile_policy(

--- a/validibot/validations/services/step_orchestrator.py
+++ b/validibot/validations/services/step_orchestrator.py
@@ -154,7 +154,10 @@ class StepOrchestrator:
 
         if not ensure_runtime_profile_supported(
             validation_run,
-            supported_profiles=(ValidationRuntimeProfile.LEGACY,),
+            supported_profiles=(
+                ValidationRuntimeProfile.LEGACY,
+                ValidationRuntimeProfile.ATTEMPT_LIFECYCLE_V1,
+            ),
             operation="execute_workflow_steps",
             sender=self.__class__,
         ):
@@ -615,7 +618,27 @@ class StepOrchestrator:
                     )
                     return step_run, False
 
-                # Step is RUNNING - this is a retry (see docstring).
+                # An attempt-mode RUNNING step can represent live or
+                # acceptance-ambiguous provider work. Never reinterpret it as
+                # a crashed task and launch a second provider execution.
+                from validibot.validations.services.runtime_profiles import (
+                    get_runtime_profile_policy,
+                )
+
+                if (
+                    get_runtime_profile_policy(
+                        validation_run.runtime_profile
+                    ).uses_execution_attempts
+                    and step_run.execution_attempts.exists()
+                ):
+                    logger.info(
+                        "Step run %s already has execution-attempt history; "
+                        "automatic task redelivery cannot relaunch it",
+                        step_run.id,
+                    )
+                    return step_run, False
+
+                # Legacy RUNNING steps retain the established retry behavior.
                 # Reset timing and clear partial findings before
                 # re-executing.
                 logger.info(
@@ -890,7 +913,10 @@ class StepOrchestrator:
         """
         if not ensure_runtime_profile_supported(
             validation_run,
-            supported_profiles=(ValidationRuntimeProfile.LEGACY,),
+            supported_profiles=(
+                ValidationRuntimeProfile.LEGACY,
+                ValidationRuntimeProfile.ATTEMPT_LIFECYCLE_V1,
+            ),
             operation="execute_workflow_step",
             sender=self.__class__,
         ):

--- a/validibot/validations/services/step_processor/advanced.py
+++ b/validibot/validations/services/step_processor/advanced.py
@@ -11,6 +11,7 @@ import logging
 from collections import Counter
 from typing import Any
 
+from validibot.validations.constants import ExecutionAttemptState
 from validibot.validations.constants import Severity
 from validibot.validations.constants import StepStatus
 from validibot.validations.models import ValidationFinding
@@ -88,6 +89,39 @@ class AdvancedValidationProcessor(ValidationStepProcessor):
 
         run_context = self._build_run_context()
 
+        # Attempt-mode runs create their durable identity before any provider
+        # work. A redelivery that observes an already-claimed attempt must not
+        # call the provider again; reconciliation owns that case.
+        from validibot.validations.services.execution import get_execution_backend
+        from validibot.validations.services.execution_attempts import (
+            get_or_create_execution_attempt,
+        )
+
+        backend = get_execution_backend()
+        attempt, attempt_created = get_or_create_execution_attempt(
+            self.step_run,
+            runner_type=backend.backend_name,
+        )
+        if (
+            attempt is not None
+            and not attempt_created
+            and attempt.state != ExecutionAttemptState.PENDING
+        ):
+            logger.info(
+                "Execution attempt %s is already %s; skipping provider relaunch",
+                attempt.pk,
+                attempt.state,
+            )
+            existing_counts = self._get_existing_finding_counts()
+            return StepProcessingResult(
+                passed=None,
+                step_run=self.step_run,
+                severity_counts=existing_counts,
+                total_findings=sum(existing_counts.values()),
+                assertion_failures=0,
+                assertion_total=0,
+            )
+
         try:
             # Call validator.validate() - this:
             # - Evaluates input-stage assertions
@@ -105,10 +139,41 @@ class AdvancedValidationProcessor(ValidationStepProcessor):
                 "Error executing advanced validation step %s",
                 self.step_run.id,
             )
+            if attempt is not None:
+                attempt.refresh_from_db(fields=["state"])
+                if attempt.state == ExecutionAttemptState.PENDING:
+                    from validibot.validations.services.execution_attempts import (
+                        transition_execution_attempt,
+                    )
+
+                    transition_execution_attempt(
+                        attempt.pk,
+                        ExecutionAttemptState.FAILED,
+                        last_error_code="validator_preparation_failed",
+                        last_error=str(e),
+                    )
             return self._handle_error(e)
 
         # Persist input-stage findings (from assertions evaluated in validate())
         severity_counts, assertion_failures = self.persist_findings(result.issues)
+
+        if attempt is not None and result.passed is False:
+            # A provider that accepted work moves the attempt out of PENDING
+            # inside its backend. Therefore a definitive failure that leaves
+            # PENDING occurred before launch and is safe to mark FAILED.
+            attempt.refresh_from_db(fields=["state"])
+            if attempt.state == ExecutionAttemptState.PENDING:
+                from validibot.validations.services.execution_attempts import (
+                    transition_execution_attempt,
+                )
+
+                target = (
+                    ExecutionAttemptState.CANCELED
+                    if (result.stats or {}).get("dispatch_skipped")
+                    == "input_stage_assertion_failed"
+                    else ExecutionAttemptState.FAILED
+                )
+                transition_execution_attempt(attempt.pk, target)
 
         # Handle sync vs async completion
         if result.passed is None:

--- a/validibot/validations/services/validation_callback.py
+++ b/validibot/validations/services/validation_callback.py
@@ -27,6 +27,7 @@ from typing import Any
 from django.conf import settings
 from django.db import DatabaseError
 from django.db import transaction
+from django.utils import timezone
 from pydantic import ValidationError
 from rest_framework import status
 from rest_framework.response import Response
@@ -202,7 +203,10 @@ class ValidationCallbackService:
                 run.status not in VALIDATION_RUN_TERMINAL_STATUSES
                 and not ensure_runtime_profile_supported(
                     run,
-                    supported_profiles=(ValidationRuntimeProfile.LEGACY,),
+                    supported_profiles=(
+                        ValidationRuntimeProfile.LEGACY,
+                        ValidationRuntimeProfile.ATTEMPT_LIFECYCLE_V1,
+                    ),
                     operation="process_validation_callback",
                     sender=self.__class__,
                 )
@@ -279,6 +283,34 @@ class ValidationCallbackService:
         5. Lock contention (another request holds the row lock) → return
            409 so Cloud Tasks retries later.
         """
+        from validibot.validations.services.execution_attempts import (
+            resolve_callback_attempt,
+        )
+        from validibot.validations.services.runtime_profiles import (
+            get_runtime_profile_policy,
+        )
+
+        attempt = None
+        if get_runtime_profile_policy(run.runtime_profile).uses_execution_attempts:
+            attempt = resolve_callback_attempt(
+                callback.callback_id,
+                run_id=run.pk,
+            )
+            if attempt is None:
+                logger.warning(
+                    "Rejected callback that was not bound to an execution attempt",
+                    extra={"run_id": str(run.pk)},
+                )
+                return Response(
+                    {"error": "Callback does not identify a valid execution attempt"},
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+            if attempt.is_terminal:
+                return self._late_callback_response(callback, run)
+            current_step = run.current_step_run
+            if current_step is None or current_step.pk != attempt.step_run_id:
+                return self._late_callback_response(callback, run)
+
         if not callback.callback_id:
             run.refresh_from_db(fields=["status"])
             if run.status in VALIDATION_RUN_TERMINAL_STATUSES:
@@ -287,6 +319,7 @@ class ValidationCallbackService:
                 callback=callback,
                 run=run,
                 receipt=None,
+                attempt=attempt,
             )
 
         try:
@@ -294,9 +327,26 @@ class ValidationCallbackService:
                 receipt, receipt_created = self._get_or_create_receipt(
                     callback,
                     run,
+                    attempt,
                 )
 
                 if not receipt_created:
+                    if (
+                        attempt is not None
+                        and receipt.execution_attempt_id != attempt.pk
+                    ):
+                        logger.error(
+                            "Callback receipt attempt binding mismatch",
+                            extra={
+                                "run_id": str(run.pk),
+                                "attempt_id": str(attempt.pk),
+                                "receipt_id": receipt.pk,
+                            },
+                        )
+                        return Response(
+                            {"error": "Callback receipt identity conflict"},
+                            status=status.HTTP_400_BAD_REQUEST,
+                        )
                     if receipt.status != CallbackReceiptStatus.PROCESSING:
                         was_rejected = receipt.status == CallbackReceiptStatus.REJECTED
                         logger.info(
@@ -348,6 +398,7 @@ class ValidationCallbackService:
                     callback=callback,
                     run=run,
                     receipt=receipt,
+                    attempt=attempt,
                 )
 
         except DatabaseError:
@@ -369,6 +420,7 @@ class ValidationCallbackService:
     def _get_or_create_receipt(
         callback: ValidationCallback,
         run: ValidationRun,
+        attempt=None,
     ) -> tuple[CallbackReceipt, bool]:
         """
         Fetch an existing receipt under a row lock, or create a new one.
@@ -384,6 +436,7 @@ class ValidationCallbackService:
             receipt = CallbackReceipt.objects.create(
                 callback_id=callback.callback_id,
                 validation_run=run,
+                execution_attempt=attempt,
                 status=CallbackReceiptStatus.PROCESSING,
                 result_uri=callback.result_uri or "",
             )
@@ -399,6 +452,7 @@ class ValidationCallbackService:
         callback: ValidationCallback,
         run: ValidationRun,
         receipt: CallbackReceipt | None,
+        attempt=None,
     ) -> Response:
         """
         Orchestrate the callback processing pipeline.
@@ -433,9 +487,33 @@ class ValidationCallbackService:
             # are left PROCESSING so the retry can re-attempt.
             if status.is_client_error(exc.status_code):
                 self._mark_receipt_rejected(callback, receipt, run)
+                if attempt is not None:
+                    from validibot.validations.constants import ExecutionAttemptState
+                    from validibot.validations.services.execution_attempts import (
+                        transition_execution_attempt,
+                    )
+
+                    transition_execution_attempt(
+                        attempt.pk,
+                        ExecutionAttemptState.FAILED,
+                        last_error_code="callback_rejected",
+                        last_error=str(exc.detail),
+                    )
             return Response(
                 {"error": exc.detail},
                 status=exc.status_code,
+            )
+
+        if attempt is not None:
+            from validibot.validations.constants import ExecutionAttemptState
+            from validibot.validations.services.execution_attempts import (
+                transition_execution_attempt,
+            )
+
+            transition_execution_attempt(
+                attempt.pk,
+                ExecutionAttemptState.COMPLETED,
+                provider_finished_at=timezone.now(),
             )
 
         self._mark_receipt_completed(callback, receipt, run)

--- a/validibot/validations/services/validation_run.py
+++ b/validibot/validations/services/validation_run.py
@@ -42,6 +42,7 @@ from typing import Any
 
 from attr import dataclass
 from attr import field
+from django.conf import settings
 from django.db import transaction
 from django.utils import timezone
 from django.utils.translation import gettext as _
@@ -108,12 +109,40 @@ def cancel_active_execution(run: ValidationRun) -> bool | None:
     if not step_run:
         return None
 
+    from validibot.validations.constants import ExecutionAttemptState
+    from validibot.validations.services.execution_attempts import (
+        get_active_execution_attempt,
+    )
     from validibot.validations.services.execution_attempts import (
         resolve_provider_execution_identity,
+    )
+    from validibot.validations.services.execution_attempts import (
+        transition_execution_attempt,
     )
     from validibot.validations.services.runtime_profiles import execution_log_context
 
     identity = resolve_provider_execution_identity(step_run)
+    attempt = get_active_execution_attempt(step_run)
+    if attempt is not None:
+        attempt_target = (
+            ExecutionAttemptState.TIMED_OUT
+            if run.status == ValidationRunStatus.TIMED_OUT
+            else ExecutionAttemptState.CANCELED
+        )
+        transition_execution_attempt(
+            attempt.pk,
+            attempt_target,
+            last_error_code=(
+                "run_timed_out"
+                if attempt_target == ExecutionAttemptState.TIMED_OUT
+                else "user_canceled"
+            ),
+            last_error=(
+                str(run.error)
+                if attempt_target == ExecutionAttemptState.TIMED_OUT
+                else str(RUN_CANCELED_MESSAGE)
+            ),
+        )
     if identity is None:
         return None
     execution_id = identity.execution_id
@@ -164,6 +193,49 @@ class ValidationRunLaunchResults:
     validation_run: ValidationRun
     data: dict[str, Any] = field(factory=dict)
     status: int | None = None
+
+
+def fence_active_execution_attempt(
+    run: ValidationRun,
+    *,
+    target,
+    error_code: str,
+    error_message: str,
+) -> None:
+    """Terminally fence an attempt inside the caller's run transaction."""
+    from validibot.validations.services.runtime_profiles import (
+        get_runtime_profile_policy,
+    )
+
+    if not get_runtime_profile_policy(run.runtime_profile).uses_execution_attempts:
+        return
+
+    step_run = (
+        ValidationStepRun.objects.filter(
+            validation_run=run,
+            status__in=[StepStatus.RUNNING, StepStatus.PENDING],
+        )
+        .order_by("step_order")
+        .first()
+    )
+    if step_run is None:
+        return
+
+    from validibot.validations.services.execution_attempts import (
+        get_active_execution_attempt,
+    )
+    from validibot.validations.services.execution_attempts import (
+        transition_execution_attempt,
+    )
+
+    attempt = get_active_execution_attempt(step_run, for_update=True)
+    if attempt is not None:
+        transition_execution_attempt(
+            attempt.pk,
+            target,
+            last_error_code=error_code,
+            last_error=error_message,
+        )
 
 
 class ValidationRunService:
@@ -309,7 +381,11 @@ class ValidationRunService:
         run_extra = dict(extra or {})
         requested_profile = run_extra.pop(
             "runtime_profile",
-            ValidationRuntimeProfile.LEGACY,
+            getattr(
+                settings,
+                "VALIDATION_RUNTIME_PROFILE",
+                ValidationRuntimeProfile.LEGACY,
+            ),
         )
         from validibot.validations.services.runtime_profiles import (
             is_runtime_profile_writer_enabled,
@@ -331,7 +407,7 @@ class ValidationRunService:
                 or getattr(workflow, "project", None),
                 user=run_user,
                 status=ValidationRunStatus.PENDING,
-                runtime_profile=ValidationRuntimeProfile.LEGACY,
+                runtime_profile=requested_profile,
                 source=source,
                 output_retention_policy=output_retention_policy,
                 output_expires_at=output_expires_at,
@@ -502,6 +578,15 @@ class ValidationRunService:
             if not locked_run.error:
                 locked_run.error = RUN_CANCELED_MESSAGE
             locked_run.save(update_fields=["status", "ended_at", "error"])
+
+            from validibot.validations.constants import ExecutionAttemptState
+
+            fence_active_execution_attempt(
+                locked_run,
+                target=ExecutionAttemptState.CANCELED,
+                error_code="user_canceled",
+                error_message=str(RUN_CANCELED_MESSAGE),
+            )
 
         # External work stays outside the database transaction. The terminal
         # decision is authoritative even if the provider is unavailable.

--- a/validibot/validations/tests/services/test_execution_backends.py
+++ b/validibot/validations/tests/services/test_execution_backends.py
@@ -48,7 +48,9 @@ from validibot_shared.validations.envelopes import SupportedMimeType
 
 from validibot.submissions.tests.factories import SubmissionFactory
 from validibot.users.tests.factories import OrganizationFactory
+from validibot.validations.constants import ExecutionAttemptState
 from validibot.validations.constants import Severity
+from validibot.validations.constants import ValidationRuntimeProfile
 from validibot.validations.constants import ValidationType
 from validibot.validations.services.cloud_run.envelope_builder import (
     build_energyplus_input_envelope,
@@ -61,6 +63,7 @@ from validibot.validations.services.execution.docker_compose import (
 from validibot.validations.services.execution.gcp import GCPExecutionBackend
 from validibot.validations.services.execution.registry import clear_backend_cache
 from validibot.validations.services.execution.registry import get_execution_backend
+from validibot.validations.tests.factories import ExecutionAttemptFactory
 from validibot.validations.tests.factories import ValidationRunFactory
 from validibot.validations.tests.factories import ValidationStepRunFactory
 from validibot.validations.tests.factories import ValidatorFactory
@@ -74,7 +77,10 @@ from validibot.workflows.tests.factories import WorkflowStepFactory
 # ==============================================================================
 
 
-def _make_execution_request() -> ExecutionRequest:
+def _make_execution_request(
+    *,
+    runtime_profile: ValidationRuntimeProfile = ValidationRuntimeProfile.LEGACY,
+) -> ExecutionRequest:
     """Build an ExecutionRequest from real Django model instances.
 
     Creates the full model graph (Org → Workflow → ValidationRun → Step)
@@ -100,6 +106,7 @@ def _make_execution_request() -> ExecutionRequest:
         submission=submission,
         workflow=workflow,
         org=org,
+        runtime_profile=runtime_profile,
     )
     # Also create a step run so validation_run.current_step_run works
     ValidationStepRunFactory(
@@ -592,6 +599,49 @@ class TestDockerComposeExecutionBackend:
 
         assert response.is_complete is True
         assert "not available" in response.error_message
+
+    @pytest.mark.django_db
+    def test_exception_after_dispatch_becomes_unknown_not_failed(self):
+        """A lost Docker response must not authorize automatic container replay.
+
+        Even though self-hosted execution is normally synchronous, the worker
+        can lose contact after Docker accepted the container. Returning a
+        pending response keeps the run available to the watchdog while the
+        durable attempt prevents task redelivery from starting another copy.
+        """
+        request = _make_execution_request(
+            runtime_profile=ValidationRuntimeProfile.ATTEMPT_LIFECYCLE_V1
+        )
+        attempt = ExecutionAttemptFactory(
+            step_run=request.run.current_step_run,
+            state=ExecutionAttemptState.PENDING,
+        )
+        workspace = MagicMock()
+        workspace.execution_bundle_container_uri = "file:///bundle"
+        workspace.input_envelope_container_uri = "file:///bundle/input.json"
+        workspace.output_envelope_container_uri = "file:///bundle/output.json"
+        envelope = MagicMock()
+        envelope.model_dump_json.return_value = "{}"
+
+        backend = DockerComposeExecutionBackend()
+        backend._runner = MagicMock()
+        backend._runner.is_available.return_value = True
+        backend._runner.run.side_effect = ConnectionError("docker response lost")
+
+        with (
+            patch.object(
+                backend,
+                "_build_workspace_and_envelope_kwargs",
+                return_value=(workspace, {}, {}),
+            ),
+            patch.object(backend, "build_input_envelope", return_value=envelope),
+        ):
+            response = backend.execute(request)
+
+        attempt.refresh_from_db()
+        assert response.is_complete is False
+        assert response.error_message is None
+        assert attempt.state == ExecutionAttemptState.UNKNOWN
 
     def test_check_status_exists(self):
         """Docker Compose backend should expose a ``check_status`` method.

--- a/validibot/validations/tests/test_execution_attempt_lifecycle_v1.py
+++ b/validibot/validations/tests/test_execution_attempt_lifecycle_v1.py
@@ -1,0 +1,230 @@
+"""End-to-end unit tests for the minimal execution-attempt writer.
+
+The lifecycle writer exists to close two costly failure windows without
+introducing a generic durable-work framework: duplicate delivery must reuse one
+attempt, and a provider call that raises after possible acceptance must become
+UNKNOWN rather than launch again. These tests exercise the concrete writer and
+Cloud Run dispatch boundary where those guarantees are established.
+"""
+
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+from validibot_shared.validations.envelopes import ValidationCallback
+from validibot_shared.validations.envelopes import ValidationStatus
+
+from validibot.validations.constants import ExecutionAttemptState
+from validibot.validations.constants import ValidationRunStatus
+from validibot.validations.services.cloud_run.launcher import (
+    ProviderDispatchAmbiguousError,
+)
+from validibot.validations.services.cloud_run.launcher import _run_validator_job_safely
+from validibot.validations.services.execution_attempts import build_attempt_callback_id
+from validibot.validations.services.execution_attempts import (
+    get_or_create_execution_attempt,
+)
+from validibot.validations.services.execution_attempts import resolve_callback_attempt
+from validibot.validations.services.execution_attempts import (
+    transition_execution_attempt,
+)
+from validibot.validations.services.step_orchestrator import StepOrchestrator
+from validibot.validations.services.validation_callback import ValidationCallbackService
+from validibot.validations.services.validation_run import fence_active_execution_attempt
+from validibot.validations.tests.factories import CallbackReceiptFactory
+from validibot.validations.tests.factories import ExecutionAttemptFactory
+from validibot.validations.tests.factories import ValidationRunFactory
+from validibot.validations.tests.factories import ValidationStepRunFactory
+
+
+@pytest.mark.django_db
+class TestExecutionAttemptWriter:
+    """Prove attempt allocation and callback identity are deterministic."""
+
+    def test_duplicate_preparation_reuses_the_active_attempt(self):
+        """Two task deliveries must converge before either can launch compute."""
+        step_run = ValidationStepRunFactory(
+            validation_run__runtime_profile="ATTEMPT_LIFECYCLE_V1"
+        )
+
+        first, first_created = get_or_create_execution_attempt(
+            step_run,
+            runner_type="GCPExecutionBackend",
+        )
+        second, second_created = get_or_create_execution_attempt(
+            step_run,
+            runner_type="GCPExecutionBackend",
+        )
+
+        assert first_created is True
+        assert second_created is False
+        assert second == first
+        assert step_run.execution_attempts.count() == 1
+
+    def test_terminal_history_allocates_the_next_attempt_number(self):
+        """An explicit later retry preserves history instead of mutating identity."""
+        first = ExecutionAttemptFactory(state=ExecutionAttemptState.PENDING)
+        transition_execution_attempt(first.pk, ExecutionAttemptState.FAILED)
+
+        second, created = get_or_create_execution_attempt(
+            first.step_run,
+            runner_type=first.runner_type,
+        )
+
+        assert created is True
+        assert second is not None
+        assert second.attempt_number == first.attempt_number + 1
+
+    def test_task_redelivery_does_not_retry_after_provider_completion(self):
+        """A crash between provider completion and step finalization stays safe."""
+        attempt = ExecutionAttemptFactory(state=ExecutionAttemptState.COMPLETED)
+
+        step_run, should_execute = StepOrchestrator()._start_step_run(
+            validation_run=attempt.step_run.validation_run,
+            workflow_step=attempt.step_run.workflow_step,
+        )
+
+        assert step_run == attempt.step_run
+        assert should_execute is False
+        assert step_run.execution_attempts.count() == 1
+
+    def test_callback_id_resolves_only_inside_its_own_run(self):
+        """An opaque callback key cannot be replayed against another tenant run."""
+        attempt = ExecutionAttemptFactory(state=ExecutionAttemptState.RUNNING)
+        callback_id = build_attempt_callback_id(attempt)
+        other_run = ValidationRunFactory(runtime_profile="ATTEMPT_LIFECYCLE_V1")
+
+        assert (
+            resolve_callback_attempt(
+                callback_id,
+                run_id=attempt.step_run.validation_run_id,
+            )
+            == attempt
+        )
+        assert resolve_callback_attempt(callback_id, run_id=other_run.pk) is None
+        assert (
+            resolve_callback_attempt(
+                "execution-attempt-not-a-uuid",
+                run_id=other_run.pk,
+            )
+            is None
+        )
+
+
+@pytest.mark.django_db
+class TestCloudRunDispatchAmbiguity:
+    """Fence the exact provider-acceptance window that can duplicate compute."""
+
+    @patch("validibot.validations.services.cloud_run.launcher.run_validator_job")
+    def test_success_records_provider_identity_before_redelivery(self, mock_run_job):
+        """A normal provider response leaves one addressable RUNNING attempt."""
+        attempt = ExecutionAttemptFactory(state=ExecutionAttemptState.PENDING)
+        mock_run_job.return_value = "projects/p/locations/r/executions/e-1"
+
+        execution_id = _run_validator_job_safely(
+            step_run=attempt.step_run,
+            project_id="project",
+            region="region",
+            job_name="validator-job",
+            input_uri="gs://bucket/input.json",
+            execution_bundle_uri="gs://bucket/bundle",
+        )
+
+        attempt.refresh_from_db()
+        assert execution_id == mock_run_job.return_value
+        assert attempt.state == ExecutionAttemptState.RUNNING
+        assert attempt.provider_execution_id == mock_run_job.return_value
+        assert attempt.provider_job_name == "validator-job"
+        assert attempt.execution_bundle_uri == "gs://bucket/bundle"
+
+    @patch("validibot.validations.services.cloud_run.launcher.run_validator_job")
+    def test_ambiguous_provider_error_is_never_relaunched(self, mock_run_job):
+        """A timeout after possible acceptance must remain UNKNOWN on redelivery."""
+        attempt = ExecutionAttemptFactory(state=ExecutionAttemptState.PENDING)
+        mock_run_job.side_effect = TimeoutError("response lost")
+        kwargs = {
+            "step_run": attempt.step_run,
+            "project_id": "project",
+            "region": "region",
+            "job_name": "validator-job",
+            "input_uri": "gs://bucket/input.json",
+            "execution_bundle_uri": "gs://bucket/bundle",
+        }
+
+        with pytest.raises(ProviderDispatchAmbiguousError):
+            _run_validator_job_safely(**kwargs)
+
+        attempt.refresh_from_db()
+        assert attempt.state == ExecutionAttemptState.UNKNOWN
+        assert mock_run_job.call_count == 1
+
+        mock_run_job.reset_mock()
+        with pytest.raises(ProviderDispatchAmbiguousError):
+            _run_validator_job_safely(**kwargs)
+        mock_run_job.assert_not_called()
+
+
+@pytest.mark.django_db
+class TestAttemptCallbackCompletion:
+    """Keep callback finalization bound to the concrete provider attempt."""
+
+    def test_verified_callback_terminally_completes_its_attempt(self):
+        """Successful output processing closes the same attempt named in delivery."""
+        attempt = ExecutionAttemptFactory(state=ExecutionAttemptState.RUNNING)
+        run = attempt.step_run.validation_run
+        receipt = CallbackReceiptFactory(
+            callback_id=build_attempt_callback_id(attempt),
+            validation_run=run,
+            execution_attempt=attempt,
+        )
+        callback = ValidationCallback(
+            run_id=str(run.pk),
+            callback_id=receipt.callback_id,
+            status=ValidationStatus.SUCCESS,
+            result_uri="gs://bucket/output.json",
+        )
+        service = ValidationCallbackService()
+        processing_result = MagicMock(step_status="PASSED")
+
+        with (
+            patch.object(
+                service,
+                "_resolve_active_step_run",
+                return_value=(attempt.step_run, MagicMock()),
+            ),
+            patch.object(service, "_download_and_validate_envelope"),
+            patch.object(
+                service,
+                "_complete_step",
+                return_value=processing_result,
+            ),
+            patch.object(service, "_finalize_or_resume"),
+            patch.object(service, "_mark_receipt_completed"),
+        ):
+            response = service._process_callback(
+                callback=callback,
+                run=run,
+                receipt=receipt,
+                attempt=attempt,
+            )
+
+        attempt.refresh_from_db()
+        assert response.status_code == 200  # noqa: PLR2004
+        assert attempt.state == ExecutionAttemptState.COMPLETED
+
+    def test_timeout_fences_attempt_before_provider_cancellation(self):
+        """A late callback cannot win after the watchdog commits its decision."""
+        attempt = ExecutionAttemptFactory(state=ExecutionAttemptState.RUNNING)
+        run = attempt.step_run.validation_run
+        run.status = ValidationRunStatus.TIMED_OUT
+        run.save(update_fields=["status"])
+
+        fence_active_execution_attempt(
+            run,
+            target=ExecutionAttemptState.TIMED_OUT,
+            error_code="run_timed_out",
+            error_message="Outer execution deadline elapsed.",
+        )
+
+        attempt.refresh_from_db()
+        assert attempt.state == ExecutionAttemptState.TIMED_OUT

--- a/validibot/validations/tests/test_execution_attempts.py
+++ b/validibot/validations/tests/test_execution_attempts.py
@@ -165,6 +165,7 @@ class TestExecutionAttemptTransitions:
             ExecutionAttemptState.PENDING: {
                 ExecutionAttemptState.PENDING,
                 ExecutionAttemptState.DISPATCHING,
+                ExecutionAttemptState.FAILED,
                 ExecutionAttemptState.CANCELED,
             },
             ExecutionAttemptState.DISPATCHING: {

--- a/validibot/validations/tests/test_gcp_reconciliation.py
+++ b/validibot/validations/tests/test_gcp_reconciliation.py
@@ -73,6 +73,7 @@ def _mock_step_run(*, output=None):
     step_run = MagicMock()
     step_run.output = output or {}
     step_run.status = StepStatus.RUNNING
+    step_run.validation_run.runtime_profile = ValidationRuntimeProfile.LEGACY
     return step_run
 
 
@@ -621,6 +622,7 @@ class TestCommandHandle(SimpleTestCase):
 
         locked_run = MagicMock()
         locked_run.status = ValidationRunStatus.RUNNING
+        locked_run.runtime_profile = ValidationRuntimeProfile.LEGACY
         locked_run.started_at = run.started_at
         mock_run_model.objects.select_for_update.return_value.get.return_value = (
             locked_run
@@ -665,6 +667,7 @@ class TestCommandHandle(SimpleTestCase):
         # Mock the atomic block and select_for_update
         locked_run = MagicMock()
         locked_run.status = ValidationRunStatus.RUNNING
+        locked_run.runtime_profile = ValidationRuntimeProfile.LEGACY
         locked_run.started_at = run.started_at
         mock_run_model.objects.select_for_update.return_value.get.return_value = (
             locked_run

--- a/validibot/validations/tests/test_runtime_profile_routing.py
+++ b/validibot/validations/tests/test_runtime_profile_routing.py
@@ -1,10 +1,9 @@
-"""Integration tests for reader-first runtime-profile routing at worker edges.
+"""Integration tests for attempt-lifecycle routing at worker edges.
 
-Stage 1 does not create attempt-mode runs, but a rolling deployment or bad
-downgrade could deliver one to a legacy worker.  These tests prove execution,
-callbacks, watchdog reconciliation, and cancellation either reject that mode
-before reading legacy metadata or use the additive attempt identity where the
-operation is already safe.
+The writer release accepts the lifecycle profile while strict-I/O profiles
+remain fenced. These tests prove attempt callbacks require durable identity,
+watchdog recovery reads attempt state, and cancellation fences the attempt
+before asking the provider to stop.
 """
 
 import uuid
@@ -16,7 +15,6 @@ from rest_framework import status
 
 from validibot.validations.constants import ExecutionAttemptState
 from validibot.validations.constants import StepStatus
-from validibot.validations.constants import ValidationRunErrorCategory
 from validibot.validations.constants import ValidationRunStatus
 from validibot.validations.constants import ValidationRuntimeProfile
 from validibot.validations.management.commands.cleanup_stuck_runs import Command
@@ -33,14 +31,14 @@ RUNNER_FACTORY_PATH = "validibot.validations.services.runners.get_validator_runn
 
 @pytest.mark.django_db
 class TestRuntimeProfileRouting:
-    """Fence attempt-mode work at every legacy execution entry point."""
+    """Route attempt-mode work without falling back to legacy metadata."""
 
     @patch("validibot.validations.signals.validation_run_finalized.send_robust")
-    def test_orchestrator_rejects_attempt_profile_before_starting_steps(
+    def test_orchestrator_accepts_attempt_profile(
         self,
         mock_finalized,
     ):
-        """A legacy worker must not dispatch an attempt run using legacy metadata."""
+        """The writer release must execute lifecycle-profile runs normally."""
         run = ValidationRunFactory(
             runtime_profile=ValidationRuntimeProfile.ATTEMPT_LIFECYCLE_V1,
             status=ValidationRunStatus.PENDING,
@@ -49,15 +47,14 @@ class TestRuntimeProfileRouting:
         result = StepOrchestrator().execute_workflow_steps(run.id, run.user_id)
 
         run.refresh_from_db()
-        assert result.status == ValidationRunStatus.FAILED
-        assert run.status == ValidationRunStatus.FAILED
-        assert run.error_category == ValidationRunErrorCategory.SYSTEM_ERROR
+        assert result.status == ValidationRunStatus.SUCCEEDED
+        assert run.status == ValidationRunStatus.SUCCEEDED
         assert run.step_runs.count() == 0
         mock_finalized.assert_called_once()
 
     @patch("validibot.validations.signals.validation_run_finalized.send_robust")
-    def test_direct_step_dispatch_cannot_bypass_profile_guard(self, mock_finalized):
-        """The compatibility facade must not offer an unguarded legacy side door."""
+    def test_direct_step_dispatch_accepts_lifecycle_profile(self, mock_finalized):
+        """The compatibility facade must route the completed profile rung."""
         run = ValidationRunFactory(
             runtime_profile=ValidationRuntimeProfile.ATTEMPT_LIFECYCLE_V1,
             status=ValidationRunStatus.RUNNING,
@@ -67,18 +64,18 @@ class TestRuntimeProfileRouting:
 
         run.refresh_from_db()
         assert result.passed is False
-        assert result.stats == {"runtime_profile_rejected": True}
-        assert run.status == ValidationRunStatus.FAILED
-        mock_finalized.assert_called_once()
+        assert result.stats == {}
+        assert run.status == ValidationRunStatus.RUNNING
+        mock_finalized.assert_not_called()
 
     @patch("validibot.validations.signals.validation_run_finalized.send_robust")
     @patch("validibot.validations.services.validation_callback.download_envelope")
-    def test_callback_rejects_attempt_profile_before_storage_read(
+    def test_callback_rejects_unbound_attempt_id_before_storage_read(
         self,
         mock_download,
         mock_finalized,
     ):
-        """An old callback handler must not parse strict output as a legacy envelope."""
+        """Attempt-mode output must identify the concrete launch that produced it."""
         run = ValidationRunFactory(
             runtime_profile=ValidationRuntimeProfile.ATTEMPT_LIFECYCLE_V1,
             status=ValidationRunStatus.RUNNING,
@@ -95,19 +92,18 @@ class TestRuntimeProfileRouting:
         )
 
         run.refresh_from_db()
-        assert response.status_code == status.HTTP_200_OK
-        assert response.data["runtime_profile_rejected"] is True
-        assert run.status == ValidationRunStatus.FAILED
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert run.status == ValidationRunStatus.RUNNING
         assert not CallbackReceipt.objects.filter(callback_id=callback_id).exists()
         mock_download.assert_not_called()
-        mock_finalized.assert_called_once()
+        mock_finalized.assert_not_called()
 
     @patch("validibot.validations.signals.validation_run_finalized.send_robust")
-    def test_watchdog_dry_run_reports_without_mutating_then_real_run_fences(
+    def test_watchdog_accepts_attempt_profile_without_provider_identity(
         self,
         mock_finalized,
     ):
-        """Dry-run remains truthful while the real legacy watchdog fails closed."""
+        """A not-yet-addressable attempt remains for timeout/operator handling."""
         run = ValidationRunFactory(
             runtime_profile=ValidationRuntimeProfile.ATTEMPT_LIFECYCLE_V1,
             status=ValidationRunStatus.RUNNING,
@@ -116,15 +112,15 @@ class TestRuntimeProfileRouting:
 
         dry_result = command._try_reconcile_gcp_run(run, dry_run=True)
         run.refresh_from_db()
-        assert dry_result == "profile_rejected"
+        assert dry_result == "not_applicable"
         assert run.status == ValidationRunStatus.RUNNING
         mock_finalized.assert_not_called()
 
         real_result = command._try_reconcile_gcp_run(run)
         run.refresh_from_db()
-        assert real_result == "profile_rejected"
-        assert run.status == ValidationRunStatus.FAILED
-        mock_finalized.assert_called_once()
+        assert real_result == "not_applicable"
+        assert run.status == ValidationRunStatus.RUNNING
+        mock_finalized.assert_not_called()
 
     @patch(RUNNER_FACTORY_PATH)
     def test_cancellation_reads_provider_identity_from_attempt(self, mock_get_runner):
@@ -151,5 +147,7 @@ class TestRuntimeProfileRouting:
 
         assert canceled is True
         updated_run.refresh_from_db()
+        attempt.refresh_from_db()
         assert updated_run.status == ValidationRunStatus.CANCELED
+        assert attempt.state == ExecutionAttemptState.CANCELED
         runner.cancel.assert_called_once_with(attempt.provider_execution_id)

--- a/validibot/validations/tests/test_runtime_profiles.py
+++ b/validibot/validations/tests/test_runtime_profiles.py
@@ -103,10 +103,13 @@ class TestRuntimeProfilePolicy:
                 expected = target_index in {current_index, current_index + 1}
                 assert can_advance_runtime_profile(current, target) is expected
 
-    def test_reader_first_release_enables_only_legacy_writers(self):
-        """Schema support must not accidentally activate attempt creation."""
+    def test_lifecycle_release_enables_only_completed_writer_rungs(self):
+        """Strict-I/O profiles remain reader-only until their ADRs complete."""
         assert is_runtime_profile_writer_enabled(ValidationRuntimeProfile.LEGACY)
-        for profile in list(ValidationRuntimeProfile)[1:]:
+        assert is_runtime_profile_writer_enabled(
+            ValidationRuntimeProfile.ATTEMPT_LIFECYCLE_V1
+        )
+        for profile in list(ValidationRuntimeProfile)[2:]:
             assert not is_runtime_profile_writer_enabled(profile)
 
     def test_unknown_profile_is_rejected(self):

--- a/validibot/validations/tests/test_validation_run_service.py
+++ b/validibot/validations/tests/test_validation_run_service.py
@@ -1,3 +1,10 @@
+"""Tests for validation-run launch, orchestration, and summary behavior.
+
+The launch tests pin transaction ordering and immutable runtime-profile
+selection; the remaining tests protect the service facade's established run
+and finding behavior while lifecycle internals evolve behind it.
+"""
+
 from collections import Counter
 
 import pytest
@@ -32,7 +39,7 @@ from validibot.workflows.tests.factories import WorkflowStepFactory
 
 @pytest.mark.django_db
 def test_launch_commits_run_before_enqueue(monkeypatch):
-    """A Stage 1 launch must persist a legacy-profile run before dispatch."""
+    """A launch must persist its immutable profile before task dispatch."""
     org = OrganizationFactory()
     user = UserFactory()
     grant_role(user, org, RoleCode.EXECUTOR)
@@ -67,8 +74,8 @@ def test_launch_commits_run_before_enqueue(monkeypatch):
 
 
 @pytest.mark.django_db
-def test_launch_refuses_reader_only_attempt_profile():
-    """Additive attempt schema must not activate a production writer early."""
+def test_launch_accepts_completed_attempt_lifecycle_profile():
+    """The completed writer rung can be selected explicitly per new run."""
     org = OrganizationFactory()
     user = UserFactory()
     grant_role(user, org, RoleCode.EXECUTOR)
@@ -83,17 +90,20 @@ def test_launch_refuses_reader_only_attempt_profile():
     request = APIRequestFactory().post("/api/v1/workflows/start/")
     request.user = user
 
-    with pytest.raises(ValueError, match="reader-only"):
-        ValidationRunService().launch(
-            request=request,
-            org=org,
-            workflow=workflow,
-            submission=submission,
-            user_id=user.id,
-            extra={"runtime_profile": (ValidationRuntimeProfile.ATTEMPT_LIFECYCLE_V1)},
-        )
+    response = ValidationRunService().launch(
+        request=request,
+        org=org,
+        workflow=workflow,
+        submission=submission,
+        user_id=user.id,
+        extra={"runtime_profile": (ValidationRuntimeProfile.ATTEMPT_LIFECYCLE_V1)},
+    )
 
-    assert not ValidationRun.objects.filter(submission=submission).exists()
+    response.validation_run.refresh_from_db()
+    assert (
+        response.validation_run.runtime_profile
+        == ValidationRuntimeProfile.ATTEMPT_LIFECYCLE_V1
+    )
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## Summary

Completes the deliberately minimal `ATTEMPT_LIFECYCLE_V1` writer built on the reader-first foundation from #256.

This PR adds the highest-value workflow-integrity controls without introducing a generic lease framework, universal outbox, second workflow runtime, or new infrastructure service:

- one durable `ExecutionAttempt` per concrete advanced-validator execution;
- monotonic attempt transitions and one-active-attempt enforcement;
- provider-acceptance ambiguity represented as `UNKNOWN`;
- task redelivery prevented from blindly relaunching claimed or historical attempts;
- callbacks bound to the concrete attempt and verified against the claimed run/current step;
- cancellation and timeout fencing in the same database transaction as the run decision;
- existing watchdog/reconciliation extended to attempt identity;
- explicit delivery bounds for both supported deployment profiles.

The deployment default remains `LEGACY`. Enabling `ATTEMPT_LIFECYCLE_V1` is a separate, explicit operational rollout after all web and worker instances run this compatible release.

## Why this scope

This is tail-risk and integrity work, not a claim of a large happy-path availability improvement. Under healthy infrastructure and Validibot's early volume, the number of avoided incidents may be close to zero. The meaningful risk is clustered failure windows: worker death, task redelivery, provider timeout after possible acceptance, lost callback, or cancellation racing completion.

Without a durable attempt identity, one such event can produce duplicate billable validator compute or contradictory evidence. The selected implementation captures most of that risk reduction using existing Django, PostgreSQL, Celery/Redis, Cloud Tasks, Cloud Run, and watchdog mechanisms.

Broader mechanisms—callback processing generations, short multi-transaction callback processing, a lifecycle outbox, automatic billable retries, completed-row partitioning, a generic deletion ledger, or another durable execution product—are deliberately not part of this PR.

## Architecture

### PostgreSQL/domain responsibilities

- Allocates attempt numbers under the logical step lock.
- Enforces one non-terminal attempt per step.
- Stores provider job/execution identity and bundle/input correlation.
- Owns monotonic state and terminal fences.
- Reuses existing run compare-and-set startup and callback receipt idempotency.
- Keeps external network/storage work outside attempt row locks.

### Self-hosted profile

- Celery retains late acknowledgement and worker-loss rejection.
- Redis visibility timeout is explicit and must exceed the Celery hard task limit.
- Synchronous Docker execution records terminal attempt state.
- An exception after Docker dispatch becomes `UNKNOWN`; it does not authorize a second container.
- A crash between provider completion and step finalization cannot cause task redelivery to relaunch the step.
- Celery Beat continues to run the existing watchdog.

### GCP profile

- Cloud Tasks keeps unique transport task names; durable identity remains in PostgreSQL.
- HTTP delivery receives an explicit bounded dispatch deadline.
- Cloud Run dispatch changes `PENDING -> DISPATCHING` immediately before the API call.
- A normal response stores provider identity and changes the attempt to `RUNNING`.
- An exception after possible acceptance changes the attempt to `UNKNOWN`; subsequent delivery cannot call Cloud Run again.
- A genuine attempt-bound callback may still complete `RUNNING` or `UNKNOWN`.
- Cloud Scheduler continues to invoke the existing watchdog/reconciliation path.

Neither deployment profile assumes exactly-once transport delivery.

## Callback and terminal behavior

- Attempt-mode callback IDs use the existing opaque callback-id field, avoiding a `validibot-shared` contract release.
- The receiver verifies attempt ownership of the run and current step before storage access.
- `CallbackReceipt.execution_attempt` is populated for attempt-mode delivery.
- Successful verified processing completes the attempt.
- Permanent callback rejection fails the attempt.
- Cancellation and timeout fence the attempt transactionally before best-effort provider cancellation.
- Late callbacks are acknowledged without reopening terminal workflow state.

The existing full callback receipt transaction remains intentionally. It is simple and safe at current scale; generation/takeover machinery is deferred until production evidence shows lock contention or stale-processor writes.

## Configuration and rollout

New settings:

- `VALIDATION_RUNTIME_PROFILE` (default `LEGACY`)
- `CELERY_VISIBILITY_TIMEOUT_SECONDS` (default 3600; must exceed the 1800-second task hard limit)
- `CLOUD_TASKS_DISPATCH_DEADLINE_SECONDS` (default 600; valid range 15–1800)

Invalid delivery bounds fail during settings initialization.

Recommended rollout:

1. Merge and deploy this reader/writer-capable release to every web and worker instance.
2. Confirm watchdog/scheduler operation and delivery configuration.
3. Enable `ATTEMPT_LIFECYCLE_V1` for a controlled deployment/cohort.
4. Observe `UNKNOWN`, late-callback, timeout, and reconciliation logs before wider rollout.
5. Roll back new-run creation to `LEGACY` if needed; already-created attempt-profile runs must continue on compatible readers.

## Compatibility

- Existing `LEGACY` runs and default behavior remain unchanged.
- No migration is required; the additive schema landed in #256.
- No `validibot-shared` change is required. This repository resolves `validibot-shared==0.12.0`, matching the latest release tag.
- No validator-backend image change is required.

## Verification

- `ruff check`: passed
- `python manage.py makemigrations --check --dry-run --settings=config.settings.test`: no changes detected
- Full repository suite: **4,511 passed, 68 subtests passed, 28 expected environment-gated skips**
- Pre-commit suite, including formatting, secret scanning and TruffleHog: passed

New regression coverage includes:

- duplicate preparation reusing one attempt;
- terminal history and explicit later attempt numbering;
- no automatic relaunch after provider completion/step-finalization crash;
- callback ownership and attempt completion;
- Cloud Run success correlation;
- Cloud Run acceptance ambiguity and no second provider call;
- Docker post-dispatch ambiguity;
- cancellation and timeout fencing;
- watchdog reconciliation using attempt identity;
- Redis visibility and Cloud Tasks deadline bounds.

## Review focus

Please pay particular attention to:

1. whether `UNKNOWN` is the correct fail-safe outcome for every post-claim uncertainty;
2. whether keeping the existing callback transaction is the right simplicity/reliability trade-off at current scale;
3. whether the explicit opt-in rollout and `LEGACY` default are sufficiently conservative;
4. whether any path could still create a second provider execution without an explicit future retry decision.
