### PR TITLE
Standardize on execution attempts

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -56,14 +56,6 @@ DEBUG = env.bool("DJANGO_DEBUG", False)
 # If not set, auto-detection is used based on other settings.
 DEPLOYMENT_TARGET = env("DEPLOYMENT_TARGET", default=None)
 
-# Immutable execution semantics recorded on each new ValidationRun. The
-# attempt lifecycle is implemented as an opt-in rollout; existing deployments
-# remain on LEGACY until every web/worker instance has the reader release.
-VALIDATION_RUNTIME_PROFILE = env(
-    "VALIDATION_RUNTIME_PROFILE",
-    default="LEGACY",
-)
-
 # App role (web vs worker). Worker instances expose internal APIs only.
 # Default to "web" for local development; production sets APP_ROLE explicitly.
 APP_ROLE = env(

--- a/docs/dev_docs/deployment/environment-configuration.md
+++ b/docs/dev_docs/deployment/environment-configuration.md
@@ -459,7 +459,6 @@ quickly the transport decides a delivery was lost:
 |---|---:|---|---|
 | `CELERY_VISIBILITY_TIMEOUT_SECONDS` | `3600` | Self-hosted Redis | Must exceed `CELERY_TASK_TIME_LIMIT` (1800 seconds), otherwise Redis can deliver a healthy long task to another worker. |
 | `CLOUD_TASKS_DISPATCH_DEADLINE_SECONDS` | `600` | GCP | Bounds the short worker HTTP orchestration request; accepted range is 15–1800 seconds. Validator compute runs separately in Cloud Run Jobs. |
-| `VALIDATION_RUNTIME_PROFILE` | `LEGACY` | All | Selects immutable semantics for newly created runs. Enable `ATTEMPT_LIFECYCLE_V1` only after all web/worker instances have the compatible release. |
 
 Transport retries never authorize a second provider launch after an attempt
 has reached `DISPATCHING`, `RUNNING`, or `UNKNOWN`.

--- a/docs/dev_docs/overview/how_it_works.md
+++ b/docs/dev_docs/overview/how_it_works.md
@@ -97,8 +97,8 @@ The `WorkflowViewSet.start_validation()` method processes the request:
    - Links the submission to the specific workflow version
    - Initializes with PENDING status
    - Records the user who triggered the validation
-   - Records an immutable runtime profile; the current reader-first release
-     creates `LEGACY` runs while preparing additive execution-attempt support
+   - Records the application-selected immutable runtime profile; every new run
+     uses the durable execution-attempt lifecycle
 
 #### 2.3 Execution Dispatch
 

--- a/docs/dev_docs/overview/service_architecture.md
+++ b/docs/dev_docs/overview/service_architecture.md
@@ -66,29 +66,26 @@ This minimises risk when refactoring a critical code path.
 
 Every `ValidationRun` records an immutable `runtime_profile`. The profile is
 chosen when the run is created and remains authoritative for its lifetime; a
-worker never infers execution behavior from nullable attempt rows or its local
+worker never infers execution behavior from nullable fields or deployment
 settings.
 
 The accepted progression is:
 
 ```text
-LEGACY
-  -> ATTEMPT_LIFECYCLE_V1
+ATTEMPT_LIFECYCLE_V1
   -> ATTEMPT_STRICT_V1
   -> ATTEMPT_CONTEXT_V1
 ```
 
 `runtime_profiles.py` is the single table describing which capabilities each
-rung adds and which I/O contract it requires. Deployments may remain on a rung
-or advance by one rung only.
+rung adds and which I/O contract it requires. Application releases may remain
+on a rung or advance by one rung only. Operators do not select a profile.
 
-The current reader-first release still creates `LEGACY` runs exclusively. It
-adds the schema and selectors required to understand attempt-mode records, but
-legacy execution, callback, and reconciliation handlers reject an attempt-mode
-run as a system error before reading legacy JSON coordination metadata. This is
-intentional downgrade protection, not a feature flag. Attempt creation is
-enabled only after every live worker and callback instance has the matching
-handler implementation.
+Every new run uses `ATTEMPT_LIFECYCLE_V1`. The older execution path was removed
+before production adoption, so dispatch, callbacks, cancellation, and
+reconciliation all use durable attempt identity. Profile guards remain only to
+protect future rolling deployments when strict I/O or canonical context is
+introduced.
 
 ### Execution attempts identify concrete provider work
 
@@ -101,8 +98,7 @@ The database permits at most one non-terminal attempt per step and prevents two
 rows from claiming the same provider execution within a runner/job namespace.
 State changes go through `execution_attempts.py`, whose small monotonic graph
 makes same-state delivery idempotent and prevents terminal attempts from
-reopening. Callback receipts have an additive nullable attempt reference;
-legacy receipts remain valid during migration.
+reopening. Every callback receipt has a required attempt reference.
 
 ## Module Responsibilities
 

--- a/docs/operations/self-hosting/configuration.md
+++ b/docs/operations/self-hosting/configuration.md
@@ -84,7 +84,6 @@ The doctor command's VB001-VB099 range checks these.
 | `VALIDATOR_RETAIN_HOURS` | How long stopped validator containers are kept before `cleanup` removes them. Default: `24`. |
 | `VALIDATOR_TIMEOUT_SECONDS` | Outer per-validator timeout and stuck-run watchdog deadline. Validators can request shorter via their manifest. |
 | `CELERY_VISIBILITY_TIMEOUT_SECONDS` | Redis redelivery window. Default: `3600`; it must remain greater than Celery's 30-minute hard task limit so a healthy long task is not delivered twice. |
-| `VALIDATION_RUNTIME_PROFILE` | Immutable semantics for newly created runs. Keep the default `LEGACY` during mixed-version deployment; use `ATTEMPT_LIFECYCLE_V1` only after every web and worker instance has the lifecycle writer release. |
 
 ### 7. Pro and signing
 

--- a/validibot/validations/constants.py
+++ b/validibot/validations/constants.py
@@ -30,7 +30,6 @@ class ValidationRuntimeProfile(TextChoices):
     by the worker that receives a task or callback.
     """
 
-    LEGACY = "LEGACY", _("Legacy execution")
     ATTEMPT_LIFECYCLE_V1 = (
         "ATTEMPT_LIFECYCLE_V1",
         _("Execution attempt lifecycle v1"),

--- a/validibot/validations/management/commands/cleanup_stuck_runs.py
+++ b/validibot/validations/management/commands/cleanup_stuck_runs.py
@@ -297,14 +297,11 @@ class Command(BaseCommand):
             - "reconciled": Run was recovered or marked failed based on GCP status
             - "still_running": Job is still executing on GCP; the caller
               applies the configured timeout fence and requests cancellation
-            - "profile_rejected": This legacy watchdog fenced an attempt-mode run
+            - "profile_rejected": This deployment cannot interpret the run profile
             - "not_applicable": Not a GCP run or missing metadata
             - "error": GCP API call failed (fall through to timeout)
         """
-        supported_profiles = (
-            ValidationRuntimeProfile.LEGACY,
-            ValidationRuntimeProfile.ATTEMPT_LIFECYCLE_V1,
-        )
+        supported_profiles = (ValidationRuntimeProfile.ATTEMPT_LIFECYCLE_V1,)
         if not is_runtime_profile_supported(run.runtime_profile, supported_profiles):
             if dry_run:
                 self.stdout.write(
@@ -337,8 +334,6 @@ class Command(BaseCommand):
         if identity is None:
             return "not_applicable"
         execution_name = identity.execution_id
-        step_output = step_run.output or {}
-
         # 3. Query Cloud Run Job status via backend
         try:
             from validibot.validations.services.execution.gcp import GCPExecutionBackend
@@ -359,10 +354,7 @@ class Command(BaseCommand):
         # 4. Act based on the explicit provider state. Human-readable messages
         # are diagnostics only and must never determine success versus failure.
         execution_status = status_response.execution_status
-        is_failed = execution_status == ExecutionStatus.FAILED or (
-            execution_status is None and bool(status_response.error_message)
-        )
-        if is_failed:
+        if execution_status == ExecutionStatus.FAILED:
             error_message = (
                 status_response.error_message or PROVIDER_FAILURE_WITHOUT_DETAILS
             )
@@ -373,7 +365,11 @@ class Command(BaseCommand):
                 )
                 return "reconciled"
 
-            self._mark_run_failed_from_gcp(run, error_message)
+            self._mark_run_failed_from_gcp(
+                run,
+                error_message,
+                attempt=identity.attempt,
+            )
             return "reconciled"
 
         if not status_response.is_complete:
@@ -385,7 +381,7 @@ class Command(BaseCommand):
             )
             return "still_running"
 
-        if execution_status not in {None, ExecutionStatus.SUCCEEDED}:
+        if execution_status != ExecutionStatus.SUCCEEDED:
             logger.warning(
                 "Cannot safely reconcile provider state %s for run %s",
                 execution_status,
@@ -403,8 +399,6 @@ class Command(BaseCommand):
 
         return self._recover_lost_callback(
             run,
-            step_run,
-            step_output,
             execution_bundle_uri=identity.execution_bundle_uri,
             attempt=identity.attempt,
         )
@@ -437,22 +431,11 @@ class Command(BaseCommand):
         self,
         run: ValidationRun,
         error_message: str,
+        *,
+        attempt,
     ) -> None:
         """Mark a run as failed based on GCP Cloud Run Job failure."""
         error_message = error_message or PROVIDER_FAILURE_WITHOUT_DETAILS
-        attempt = None
-        from validibot.validations.services.runtime_profiles import (
-            get_runtime_profile_policy,
-        )
-
-        if get_runtime_profile_policy(run.runtime_profile).uses_execution_attempts:
-            step_run = self._get_active_step_run(run)
-            from validibot.validations.services.execution_attempts import (
-                get_active_execution_attempt,
-            )
-
-            if step_run is not None:
-                attempt = get_active_execution_attempt(step_run)
 
         with transaction.atomic():
             locked = ValidationRun.objects.select_for_update().get(pk=run.pk)
@@ -491,19 +474,18 @@ class Command(BaseCommand):
                 },
             )
 
-        if attempt is not None:
-            from validibot.validations.constants import ExecutionAttemptState
-            from validibot.validations.services.execution_attempts import (
-                transition_execution_attempt,
-            )
+        from validibot.validations.constants import ExecutionAttemptState
+        from validibot.validations.services.execution_attempts import (
+            transition_execution_attempt,
+        )
 
-            transition_execution_attempt(
-                attempt.pk,
-                ExecutionAttemptState.FAILED,
-                provider_finished_at=timezone.now(),
-                last_error_code="provider_failed",
-                last_error=error_message,
-            )
+        transition_execution_attempt(
+            attempt.pk,
+            ExecutionAttemptState.FAILED,
+            provider_finished_at=timezone.now(),
+            last_error_code="provider_failed",
+            last_error=error_message,
+        )
 
         from validibot.validations.signals import validation_run_finalized
 
@@ -515,11 +497,9 @@ class Command(BaseCommand):
     def _recover_lost_callback(
         self,
         run: ValidationRun,
-        step_run: ValidationStepRun,
-        step_output: dict,
         *,
-        execution_bundle_uri: str = "",
-        attempt=None,
+        execution_bundle_uri: str,
+        attempt,
     ) -> str:
         """
         Recover a completed GCP run by processing a synthetic callback.
@@ -534,18 +514,15 @@ class Command(BaseCommand):
 
         Args:
             run: The stuck ValidationRun.
-            step_run: The active step run with GCP metadata.
-            step_output: The step_run.output dict containing execution metadata.
+            execution_bundle_uri: Durable bundle location recorded on the attempt.
+            attempt: The concrete provider execution being reconciled.
 
         Returns:
             "reconciled" on success, "error" on failure.
         """
-        execution_bundle_uri = execution_bundle_uri or step_output.get(
-            "execution_bundle_uri", ""
-        )
         if not execution_bundle_uri:
             logger.warning(
-                "Cannot recover run %s: no execution_bundle_uri in step output",
+                "Cannot recover run %s: its attempt has no execution bundle URI",
                 run.id,
             )
             return "error"
@@ -556,13 +533,11 @@ class Command(BaseCommand):
         # Build a synthetic callback payload
         from validibot_shared.validations.envelopes import ValidationStatus
 
-        callback_id = f"reconciliation-{run.id}"
-        if attempt is not None:
-            from validibot.validations.services.execution_attempts import (
-                build_attempt_callback_id,
-            )
+        from validibot.validations.services.execution_attempts import (
+            build_attempt_callback_id,
+        )
 
-            callback_id = build_attempt_callback_id(attempt)
+        callback_id = build_attempt_callback_id(attempt)
 
         callback_payload = {
             "run_id": str(run.id),

--- a/validibot/validations/migrations/0066_standardize_attempt_lifecycle.py
+++ b/validibot/validations/migrations/0066_standardize_attempt_lifecycle.py
@@ -1,0 +1,63 @@
+import django.db.models.deletion
+from django.db import migrations
+from django.db import models
+
+
+def delete_unbound_callback_receipts(apps, schema_editor):
+    """Discard rollout-era receipts that cannot identify provider work.
+
+    Callback receipts are short-lived idempotency records, not validation
+    evidence. Before production adoption there is no reason to preserve rows
+    created by the retired callback path without an execution attempt.
+    """
+    callback_receipt = apps.get_model("validations", "CallbackReceipt")
+    callback_receipt.objects.filter(execution_attempt__isnull=True).delete()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("validations", "0065_validationrun_runtime_profile_executionattempt_and_more"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            delete_unbound_callback_receipts,
+            reverse_code=migrations.RunPython.noop,
+        ),
+        migrations.AlterField(
+            model_name="callbackreceipt",
+            name="execution_attempt",
+            field=models.ForeignKey(
+                help_text="The concrete execution that produced this callback.",
+                on_delete=django.db.models.deletion.RESTRICT,
+                related_name="callback_receipts",
+                to="validations.executionattempt",
+            ),
+        ),
+        migrations.AlterField(
+            model_name="validationrun",
+            name="runtime_profile",
+            field=models.CharField(
+                choices=[
+                    (
+                        "ATTEMPT_LIFECYCLE_V1",
+                        "Execution attempt lifecycle v1",
+                    ),
+                    (
+                        "ATTEMPT_STRICT_V1",
+                        "Strict execution attempt I/O v1",
+                    ),
+                    (
+                        "ATTEMPT_CONTEXT_V1",
+                        "Canonical run context v1",
+                    ),
+                ],
+                default="ATTEMPT_LIFECYCLE_V1",
+                editable=False,
+                help_text=(
+                    "Immutable execution semantics selected when this run was created."
+                ),
+                max_length=32,
+            ),
+        ),
+    ]

--- a/validibot/validations/models.py
+++ b/validibot/validations/models.py
@@ -2753,7 +2753,7 @@ class ValidationRun(TimeStampedModel):
     runtime_profile = models.CharField(
         max_length=32,
         choices=ValidationRuntimeProfile.choices,
-        default=ValidationRuntimeProfile.LEGACY,
+        default=ValidationRuntimeProfile.ATTEMPT_LIFECYCLE_V1,
         editable=False,
         help_text=_(
             "Immutable execution semantics selected when this run was created."
@@ -3102,8 +3102,7 @@ class ExecutionAttempt(TimeStampedModel):
     The step run remains the workflow-level unit.  This row gives each actual
     container or cloud job a durable identity so retries, callbacks,
     reconciliation, cancellation, evidence, and billing can all refer to the
-    same launch.  Stage 1 adds this reader-first schema but does not create
-    attempts in production; attempt writers are enabled in a later stage.
+    same launch.
     """
 
     class Meta:
@@ -3226,8 +3225,6 @@ class ExecutionAttempt(TimeStampedModel):
             self.step_run.validation_run.runtime_profile
         )
         errors = {}
-        if not policy.uses_execution_attempts:
-            errors["step_run"] = _("Legacy runs cannot contain execution attempts.")
         if self.contract_version != policy.contract_version:
             errors["contract_version"] = _(
                 "The attempt contract must match its run's runtime profile."
@@ -3521,13 +3518,8 @@ class CallbackReceipt(models.Model):
     execution_attempt = models.ForeignKey(
         ExecutionAttempt,
         on_delete=models.RESTRICT,
-        null=True,
-        blank=True,
         related_name="callback_receipts",
-        help_text=_(
-            "The concrete execution that produced this callback. "
-            "Null only for legacy callbacks during migration."
-        ),
+        help_text=_("The concrete execution that produced this callback."),
     )
 
     received_at = models.DateTimeField(

--- a/validibot/validations/services/cloud_run/launcher.py
+++ b/validibot/validations/services/cloud_run/launcher.py
@@ -202,7 +202,7 @@ class ProviderDispatchAmbiguousError(RuntimeError):
 
 
 def _callback_id_for_step(step_run) -> str:
-    """Bind attempt-mode callbacks to one launch, retaining legacy ids."""
+    """Bind the callback to the step's one active execution attempt."""
     from validibot.validations.services.execution_attempts import (
         build_attempt_callback_id,
     )
@@ -211,9 +211,10 @@ def _callback_id_for_step(step_run) -> str:
     )
 
     attempt = get_active_execution_attempt(step_run)
-    if attempt is not None:
-        return build_attempt_callback_id(attempt)
-    return f"step-run-{step_run.id}"
+    if attempt is None:
+        msg = f"Validation step {step_run.pk} has no active execution attempt"
+        raise RuntimeError(msg)
+    return build_attempt_callback_id(attempt)
 
 
 def _run_validator_job_safely(
@@ -227,9 +228,8 @@ def _run_validator_job_safely(
 ) -> str:
     """Launch once and preserve provider-acceptance ambiguity explicitly.
 
-    Legacy runs retain their existing direct call. Attempt-mode runs claim the
-    durable row immediately before the external API. If the call raises, the
-    attempt becomes UNKNOWN and no delivery is allowed to launch it again.
+    The durable row is claimed immediately before the external API. If the call
+    raises, the attempt becomes UNKNOWN and no delivery may launch it again.
     """
     from validibot.validations.constants import ExecutionAttemptState
     from validibot.validations.services.execution_attempts import (
@@ -241,12 +241,8 @@ def _run_validator_job_safely(
 
     attempt = get_active_execution_attempt(step_run)
     if attempt is None:
-        return run_validator_job(
-            project_id=project_id,
-            region=region,
-            job_name=job_name,
-            input_uri=input_uri,
-        )
+        msg = f"Validation step {step_run.pk} has no active execution attempt"
+        raise RuntimeError(msg)
 
     if attempt.state != ExecutionAttemptState.PENDING:
         if attempt.state == ExecutionAttemptState.RUNNING and (

--- a/validibot/validations/services/execution/base.py
+++ b/validibot/validations/services/execution/base.py
@@ -131,9 +131,8 @@ class ExecutionResponse:
 
     Callers must use this field, rather than the presence of human-readable
     error text, when deciding whether a completed execution succeeded.
-    ``None`` remains available for legacy responses during the compatibility
-    window. It is appended to preserve the positional constructor used by any
-    older integration.
+    ``None`` is used for launch responses that do not represent a provider
+    status observation.
     """
 
 

--- a/validibot/validations/services/execution/docker_compose.py
+++ b/validibot/validations/services/execution/docker_compose.py
@@ -236,7 +236,19 @@ class DockerComposeExecutionBackend(ExecutionBackend):
         )
 
         step_run = request.run.current_step_run
-        attempt = get_active_execution_attempt(step_run) if step_run else None
+        if step_run is None:
+            return ExecutionResponse(
+                execution_id="",
+                is_complete=True,
+                error_message="Validation run has no active step",
+            )
+        attempt = get_active_execution_attempt(step_run)
+        if attempt is None:
+            return ExecutionResponse(
+                execution_id="",
+                is_complete=True,
+                error_message="Validation step has no active execution attempt",
+            )
 
         try:
             # 1. Build the per-run workspace and the envelope override
@@ -248,11 +260,7 @@ class DockerComposeExecutionBackend(ExecutionBackend):
             # 2. Build callback URL and ID (unused for sync, but the
             # envelope schema still requires the fields).
             callback_url = self._get_callback_url()
-            callback_id = (
-                build_attempt_callback_id(attempt)
-                if attempt is not None
-                else f"step-run-{request.run.current_step_run.id}"
-            )
+            callback_id = build_attempt_callback_id(attempt)
 
             # 3. Build the envelope with container-visible URIs.
             envelope = self.build_input_envelope(
@@ -279,19 +287,18 @@ class DockerComposeExecutionBackend(ExecutionBackend):
                 workspace.host_input_envelope_path,
             )
 
-            if attempt is not None:
-                attempt, claimed = transition_execution_attempt(
-                    attempt.pk,
-                    ExecutionAttemptState.DISPATCHING,
-                    execution_bundle_uri=workspace.execution_bundle_container_uri,
-                    input_envelope_uri=workspace.input_envelope_container_uri,
+            attempt, claimed = transition_execution_attempt(
+                attempt.pk,
+                ExecutionAttemptState.DISPATCHING,
+                execution_bundle_uri=workspace.execution_bundle_container_uri,
+                input_envelope_uri=workspace.input_envelope_container_uri,
+            )
+            if not claimed:
+                return ExecutionResponse(
+                    execution_id=attempt.provider_execution_id,
+                    is_complete=False,
+                    execution_bundle_uri=attempt.execution_bundle_uri,
                 )
-                if not claimed:
-                    return ExecutionResponse(
-                        execution_id=attempt.provider_execution_id,
-                        is_complete=False,
-                        execution_bundle_uri=attempt.execution_bundle_uri,
-                    )
 
             # 5. Resolve container image.
             container_image = self.get_container_image(request.validator_type)
@@ -341,16 +348,15 @@ class DockerComposeExecutionBackend(ExecutionBackend):
                     result.exit_code,
                     error_msg,
                 )
-                if attempt is not None:
-                    transition_execution_attempt(
-                        attempt.pk,
-                        ExecutionAttemptState.FAILED,
-                        provider_execution_id=result.execution_id or execution_id,
-                        provider_finished_at=timezone.now(),
-                        last_error_code="container_execution_failed",
-                        last_error=error_msg,
-                        backend_image_digest=result.validator_backend_image_digest,
-                    )
+                transition_execution_attempt(
+                    attempt.pk,
+                    ExecutionAttemptState.FAILED,
+                    provider_execution_id=result.execution_id or execution_id,
+                    provider_finished_at=timezone.now(),
+                    last_error_code="container_execution_failed",
+                    last_error=error_msg,
+                    backend_image_digest=result.validator_backend_image_digest,
+                )
                 return ExecutionResponse(
                     execution_id=result.execution_id or execution_id,
                     is_complete=True,
@@ -369,14 +375,19 @@ class DockerComposeExecutionBackend(ExecutionBackend):
                 workspace.host_output_envelope_path,
             )
 
-            if attempt is not None:
-                transition_execution_attempt(
-                    attempt.pk,
-                    ExecutionAttemptState.COMPLETED,
-                    provider_execution_id=result.execution_id or execution_id,
-                    provider_finished_at=timezone.now(),
-                    backend_image_digest=result.validator_backend_image_digest,
-                )
+            attempt, _ = transition_execution_attempt(
+                attempt.pk,
+                ExecutionAttemptState.RUNNING,
+                provider_execution_id=result.execution_id or execution_id,
+                provider_started_at=attempt.dispatch_started_at or timezone.now(),
+                backend_image_digest=result.validator_backend_image_digest,
+            )
+            transition_execution_attempt(
+                attempt.pk,
+                ExecutionAttemptState.COMPLETED,
+                provider_finished_at=timezone.now(),
+                backend_image_digest=result.validator_backend_image_digest,
+            )
 
             logger.info(
                 "Container execution completed for run %s in %.2fs",
@@ -397,14 +408,13 @@ class DockerComposeExecutionBackend(ExecutionBackend):
 
         except TimeoutError as e:
             logger.exception("Container execution timed out for run %s", request.run_id)
-            if attempt is not None:
-                transition_execution_attempt(
-                    attempt.pk,
-                    ExecutionAttemptState.TIMED_OUT,
-                    provider_finished_at=timezone.now(),
-                    last_error_code="container_timeout",
-                    last_error=str(e),
-                )
+            transition_execution_attempt(
+                attempt.pk,
+                ExecutionAttemptState.TIMED_OUT,
+                provider_finished_at=timezone.now(),
+                last_error_code="container_timeout",
+                last_error=str(e),
+            )
             return ExecutionResponse(
                 execution_id=execution_id,
                 is_complete=True,
@@ -414,23 +424,22 @@ class DockerComposeExecutionBackend(ExecutionBackend):
         except Exception as e:
             logger.exception("Failed to execute validation for run %s", request.run_id)
             dispatch_is_ambiguous = False
-            if attempt is not None:
-                attempt.refresh_from_db(fields=["state"])
-                if attempt.state == ExecutionAttemptState.DISPATCHING:
-                    transition_execution_attempt(
-                        attempt.pk,
-                        ExecutionAttemptState.UNKNOWN,
-                        last_error_code="container_state_unknown",
-                        last_error=str(e),
-                    )
-                    dispatch_is_ambiguous = True
-                elif attempt.state == ExecutionAttemptState.PENDING:
-                    transition_execution_attempt(
-                        attempt.pk,
-                        ExecutionAttemptState.FAILED,
-                        last_error_code="container_preparation_failed",
-                        last_error=str(e),
-                    )
+            attempt.refresh_from_db(fields=["state"])
+            if attempt.state == ExecutionAttemptState.DISPATCHING:
+                transition_execution_attempt(
+                    attempt.pk,
+                    ExecutionAttemptState.UNKNOWN,
+                    last_error_code="container_state_unknown",
+                    last_error=str(e),
+                )
+                dispatch_is_ambiguous = True
+            elif attempt.state == ExecutionAttemptState.PENDING:
+                transition_execution_attempt(
+                    attempt.pk,
+                    ExecutionAttemptState.FAILED,
+                    last_error_code="container_preparation_failed",
+                    last_error=str(e),
+                )
             return ExecutionResponse(
                 execution_id=execution_id,
                 is_complete=not dispatch_is_ambiguous,

--- a/validibot/validations/services/execution_attempts.py
+++ b/validibot/validations/services/execution_attempts.py
@@ -1,8 +1,7 @@
-"""Reader-first selectors and monotonic transitions for execution attempts.
+"""Allocation, lookup, and monotonic transitions for execution attempts.
 
-Stage 1 introduces the attempt aggregate without enabling production attempt
-creation.  Keeping its small transition graph and provider-identity lookup in
-one module prevents callbacks, cancellation, reconciliation, and future
+Keeping the attempt aggregate's small transition graph and provider-identity
+lookup in one module prevents callbacks, cancellation, reconciliation, and
 dispatch code from inventing subtly different lifecycle rules.
 """
 
@@ -39,12 +38,12 @@ class InvalidExecutionAttemptTransitionError(ValueError):
 
 @dataclass(frozen=True, slots=True)
 class ProviderExecutionIdentity:
-    """Provider address and workspace resolved from legacy or attempt storage."""
+    """Provider address and workspace resolved from durable attempt storage."""
 
     execution_id: str
     execution_bundle_uri: str
     runner_type: str
-    attempt: ExecutionAttempt | None
+    attempt: ExecutionAttempt
 
 
 ATTEMPT_CALLBACK_PREFIX = "execution-attempt-"
@@ -60,12 +59,11 @@ def resolve_callback_attempt(
     *,
     run_id: UUID | str,
 ) -> ExecutionAttempt | None:
-    """Resolve an attempt-mode callback without trusting its run identifier.
+    """Resolve an attempt-bound callback without trusting its run identifier.
 
     The callback id is an opaque idempotency key in the shared envelope
     contract. Attempt-mode writers encode the attempt UUID in that key, while
-    this reader verifies the database relationship back to ``run_id``. Legacy
-    ``step-run-*`` callback ids intentionally return ``None``.
+    this reader verifies the database relationship back to ``run_id``.
     """
     from validibot.validations.models import ExecutionAttempt
 
@@ -87,13 +85,12 @@ def get_or_create_execution_attempt(
     step_run: ValidationStepRun,
     *,
     runner_type: str,
-) -> tuple[ExecutionAttempt | None, bool]:
-    """Return the active attempt, creating it for an attempt-mode run.
+) -> tuple[ExecutionAttempt, bool]:
+    """Return the active attempt, creating it before provider work begins.
 
     Locking the logical step makes attempt-number allocation deterministic and
     complements the partial unique constraint that permits only one active
-    attempt. Legacy runs return ``(None, False)`` so callers can keep their
-    established behavior during the compatibility window.
+    attempt.
     """
     from validibot.validations.models import ExecutionAttempt
     from validibot.validations.models import ValidationStepRun
@@ -105,8 +102,6 @@ def get_or_create_execution_attempt(
             .get(pk=step_run.pk)
         )
         policy = get_runtime_profile_policy(locked_step.validation_run.runtime_profile)
-        if not policy.uses_execution_attempts:
-            return None, False
 
         active = get_active_execution_attempt(locked_step, for_update=True)
         if active is not None:
@@ -201,38 +196,20 @@ def get_active_execution_attempt(
 def resolve_provider_execution_identity(
     step_run: ValidationStepRun,
 ) -> ProviderExecutionIdentity | None:
-    """Read provider identity from the source selected by the run profile.
-
-    Legacy runs continue reading coordination metadata from ``step_run.output``.
-    Attempt profiles read the active attempt row and never fall back to legacy
-    JSON, which prevents mixed-version code from silently using stale identity.
-    """
-    policy = get_runtime_profile_policy(step_run.validation_run.runtime_profile)
-    if policy.uses_execution_attempts:
-        attempt = get_active_execution_attempt(step_run)
-        if attempt is None:
-            # Terminal fencing deliberately happens before best-effort provider
-            # cancellation. Retain the latest attempt's provider address so
-            # the external cancel request can run after the DB commit.
-            attempt = step_run.execution_attempts.order_by("-attempt_number").first()
-        if attempt is None or not attempt.provider_execution_id:
-            return None
-        return ProviderExecutionIdentity(
-            execution_id=attempt.provider_execution_id,
-            execution_bundle_uri=attempt.execution_bundle_uri,
-            runner_type=attempt.runner_type,
-            attempt=attempt,
-        )
-
-    step_output = step_run.output or {}
-    execution_id = step_output.get("execution_name") or step_output.get("execution_id")
-    if not execution_id:
+    """Read provider identity exclusively from durable attempt storage."""
+    attempt = get_active_execution_attempt(step_run)
+    if attempt is None:
+        # Terminal fencing deliberately happens before best-effort provider
+        # cancellation. Retain the latest attempt's provider address so the
+        # external cancel request can run after the DB commit.
+        attempt = step_run.execution_attempts.order_by("-attempt_number").first()
+    if attempt is None or not attempt.provider_execution_id:
         return None
     return ProviderExecutionIdentity(
-        execution_id=str(execution_id),
-        execution_bundle_uri=str(step_output.get("execution_bundle_uri", "")),
-        runner_type="",
-        attempt=None,
+        execution_id=attempt.provider_execution_id,
+        execution_bundle_uri=attempt.execution_bundle_uri,
+        runner_type=attempt.runner_type,
+        attempt=attempt,
     )
 
 

--- a/validibot/validations/services/runtime_profiles.py
+++ b/validibot/validations/services/runtime_profiles.py
@@ -1,10 +1,9 @@
 """Runtime-profile policy and mixed-version execution guards.
 
-The validation-execution integrity program introduces execution behavior in
-reader-first releases.  This module is the single table that explains each
-accepted profile and the guard used by legacy handlers until attempt writers
-are enabled.  It deliberately avoids feature-flag inference: the immutable
-value stored on each run is authoritative for that run's lifetime.
+Every validation uses the durable execution-attempt lifecycle. Runtime
+profiles version additional semantics, such as strict I/O, without exposing an
+operator switch or maintaining parallel execution engines. The immutable value
+stored on each run remains authoritative for that run's lifetime.
 """
 
 from __future__ import annotations
@@ -47,58 +46,40 @@ class RuntimeProfilePolicy:
 
     profile: ValidationRuntimeProfile
     contract_version: ExecutionContractVersion
-    uses_execution_attempts: bool
     uses_strict_io: bool
     uses_canonical_context: bool
 
 
 _PROFILE_SEQUENCE = (
-    ValidationRuntimeProfile.LEGACY,
     ValidationRuntimeProfile.ATTEMPT_LIFECYCLE_V1,
     ValidationRuntimeProfile.ATTEMPT_STRICT_V1,
     ValidationRuntimeProfile.ATTEMPT_CONTEXT_V1,
 )
 
 _PROFILE_POLICIES = {
-    ValidationRuntimeProfile.LEGACY: RuntimeProfilePolicy(
-        profile=ValidationRuntimeProfile.LEGACY,
-        contract_version=ExecutionContractVersion.LEGACY_URI_V1,
-        uses_execution_attempts=False,
-        uses_strict_io=False,
-        uses_canonical_context=False,
-    ),
     ValidationRuntimeProfile.ATTEMPT_LIFECYCLE_V1: RuntimeProfilePolicy(
         profile=ValidationRuntimeProfile.ATTEMPT_LIFECYCLE_V1,
         contract_version=ExecutionContractVersion.LEGACY_URI_V1,
-        uses_execution_attempts=True,
         uses_strict_io=False,
         uses_canonical_context=False,
     ),
     ValidationRuntimeProfile.ATTEMPT_STRICT_V1: RuntimeProfilePolicy(
         profile=ValidationRuntimeProfile.ATTEMPT_STRICT_V1,
         contract_version=ExecutionContractVersion.STRICT_CONTENT_V1,
-        uses_execution_attempts=True,
         uses_strict_io=True,
         uses_canonical_context=False,
     ),
     ValidationRuntimeProfile.ATTEMPT_CONTEXT_V1: RuntimeProfilePolicy(
         profile=ValidationRuntimeProfile.ATTEMPT_CONTEXT_V1,
         contract_version=ExecutionContractVersion.STRICT_CONTENT_V1,
-        uses_execution_attempts=True,
         uses_strict_io=True,
         uses_canonical_context=True,
     ),
 }
 
-# Stage 1 is intentionally reader-first.  Later stages expand this set only
-# after every callback, task, watchdog, and reconciliation instance can handle
-# the next profile.
-WRITER_ENABLED_RUNTIME_PROFILES = frozenset(
-    {
-        ValidationRuntimeProfile.LEGACY,
-        ValidationRuntimeProfile.ATTEMPT_LIFECYCLE_V1,
-    }
-)
+# New runs use one application-selected profile. This is intentionally not a
+# deployment setting: operators should never choose between execution engines.
+NEW_RUN_RUNTIME_PROFILE = ValidationRuntimeProfile.ATTEMPT_LIFECYCLE_V1
 
 
 def get_runtime_profile_policy(
@@ -119,16 +100,21 @@ def get_runtime_profile_policy(
         raise UnsupportedRuntimeProfileError(
             f"Unsupported validation runtime profile: {profile!r}"
         ) from exc
-    return _PROFILE_POLICIES[normalized]
+    try:
+        return _PROFILE_POLICIES[normalized]
+    except KeyError as exc:
+        raise UnsupportedRuntimeProfileError(
+            f"Unsupported validation runtime profile: {profile!r}"
+        ) from exc
 
 
 def can_advance_runtime_profile(
     current: str | ValidationRuntimeProfile,
     target: str | ValidationRuntimeProfile,
 ) -> bool:
-    """Return whether a deployment default may move to the next profile rung.
+    """Return whether an application release may move to the next profile rung.
 
-    A deployment may remain on its current rung or advance by exactly one.
+    A release may remain on its current rung or advance by exactly one.
     Skipping a rung would bypass its mixed-version rollout gate; moving
     backwards could create runs that an older release misinterprets.
     """
@@ -137,15 +123,6 @@ def can_advance_runtime_profile(
     current_index = _PROFILE_SEQUENCE.index(current_policy.profile)
     target_index = _PROFILE_SEQUENCE.index(target_policy.profile)
     return target_index in {current_index, current_index + 1}
-
-
-def is_runtime_profile_writer_enabled(
-    profile: str | ValidationRuntimeProfile,
-) -> bool:
-    """Return whether this release is allowed to create runs in ``profile``."""
-    return (
-        get_runtime_profile_policy(profile).profile in WRITER_ENABLED_RUNTIME_PROFILES
-    )
 
 
 def is_runtime_profile_supported(
@@ -190,11 +167,9 @@ def ensure_runtime_profile_supported(
 ) -> bool:
     """Fence a run when a handler cannot safely interpret its profile.
 
-    Existing execution handlers call this before reading legacy step-output
-    metadata.  During Stage 1 they support ``LEGACY`` only.  If an attempt-mode
-    task reaches an old handler during a bad rollout or downgrade, the run is
-    terminally failed as a system error rather than silently processed as a
-    legacy run.
+    Execution handlers call this before interpreting profile-specific data. If
+    work reaches a handler that predates the stored profile during a bad
+    rollout or downgrade, the run is terminally failed as a system error.
 
     Returns:
         ``True`` when the caller may continue, otherwise ``False`` after the

--- a/validibot/validations/services/step_orchestrator.py
+++ b/validibot/validations/services/step_orchestrator.py
@@ -154,10 +154,7 @@ class StepOrchestrator:
 
         if not ensure_runtime_profile_supported(
             validation_run,
-            supported_profiles=(
-                ValidationRuntimeProfile.LEGACY,
-                ValidationRuntimeProfile.ATTEMPT_LIFECYCLE_V1,
-            ),
+            supported_profiles=(ValidationRuntimeProfile.ATTEMPT_LIFECYCLE_V1,),
             operation="execute_workflow_steps",
             sender=self.__class__,
         ):
@@ -618,19 +615,10 @@ class StepOrchestrator:
                     )
                     return step_run, False
 
-                # An attempt-mode RUNNING step can represent live or
+                # A RUNNING step with attempt history can represent live or
                 # acceptance-ambiguous provider work. Never reinterpret it as
                 # a crashed task and launch a second provider execution.
-                from validibot.validations.services.runtime_profiles import (
-                    get_runtime_profile_policy,
-                )
-
-                if (
-                    get_runtime_profile_policy(
-                        validation_run.runtime_profile
-                    ).uses_execution_attempts
-                    and step_run.execution_attempts.exists()
-                ):
+                if step_run.execution_attempts.exists():
                     logger.info(
                         "Step run %s already has execution-attempt history; "
                         "automatic task redelivery cannot relaunch it",
@@ -638,9 +626,8 @@ class StepOrchestrator:
                     )
                     return step_run, False
 
-                # Legacy RUNNING steps retain the established retry behavior.
-                # Reset timing and clear partial findings before
-                # re-executing.
+                # A step without attempt history failed before it could claim
+                # provider work, so resetting its local bookkeeping is safe.
                 logger.info(
                     "Step run %s is RUNNING (retry scenario), "
                     "clearing findings and resetting timer",
@@ -913,10 +900,7 @@ class StepOrchestrator:
         """
         if not ensure_runtime_profile_supported(
             validation_run,
-            supported_profiles=(
-                ValidationRuntimeProfile.LEGACY,
-                ValidationRuntimeProfile.ATTEMPT_LIFECYCLE_V1,
-            ),
+            supported_profiles=(ValidationRuntimeProfile.ATTEMPT_LIFECYCLE_V1,),
             operation="execute_workflow_step",
             sender=self.__class__,
         ):

--- a/validibot/validations/services/step_processor/advanced.py
+++ b/validibot/validations/services/step_processor/advanced.py
@@ -89,9 +89,9 @@ class AdvancedValidationProcessor(ValidationStepProcessor):
 
         run_context = self._build_run_context()
 
-        # Attempt-mode runs create their durable identity before any provider
-        # work. A redelivery that observes an already-claimed attempt must not
-        # call the provider again; reconciliation owns that case.
+        # Create durable identity before any provider work. A redelivery that
+        # observes an already-claimed attempt must not call the provider again;
+        # reconciliation owns that case.
         from validibot.validations.services.execution import get_execution_backend
         from validibot.validations.services.execution_attempts import (
             get_or_create_execution_attempt,
@@ -102,11 +102,7 @@ class AdvancedValidationProcessor(ValidationStepProcessor):
             self.step_run,
             runner_type=backend.backend_name,
         )
-        if (
-            attempt is not None
-            and not attempt_created
-            and attempt.state != ExecutionAttemptState.PENDING
-        ):
+        if not attempt_created and attempt.state != ExecutionAttemptState.PENDING:
             logger.info(
                 "Execution attempt %s is already %s; skipping provider relaunch",
                 attempt.pk,
@@ -139,25 +135,24 @@ class AdvancedValidationProcessor(ValidationStepProcessor):
                 "Error executing advanced validation step %s",
                 self.step_run.id,
             )
-            if attempt is not None:
-                attempt.refresh_from_db(fields=["state"])
-                if attempt.state == ExecutionAttemptState.PENDING:
-                    from validibot.validations.services.execution_attempts import (
-                        transition_execution_attempt,
-                    )
+            attempt.refresh_from_db(fields=["state"])
+            if attempt.state == ExecutionAttemptState.PENDING:
+                from validibot.validations.services.execution_attempts import (
+                    transition_execution_attempt,
+                )
 
-                    transition_execution_attempt(
-                        attempt.pk,
-                        ExecutionAttemptState.FAILED,
-                        last_error_code="validator_preparation_failed",
-                        last_error=str(e),
-                    )
+                transition_execution_attempt(
+                    attempt.pk,
+                    ExecutionAttemptState.FAILED,
+                    last_error_code="validator_preparation_failed",
+                    last_error=str(e),
+                )
             return self._handle_error(e)
 
         # Persist input-stage findings (from assertions evaluated in validate())
         severity_counts, assertion_failures = self.persist_findings(result.issues)
 
-        if attempt is not None and result.passed is False:
+        if result.passed is False:
             # A provider that accepted work moves the attempt out of PENDING
             # inside its backend. Therefore a definitive failure that leaves
             # PENDING occurred before launch and is safe to mark FAILED.

--- a/validibot/validations/services/validation_callback.py
+++ b/validibot/validations/services/validation_callback.py
@@ -203,10 +203,7 @@ class ValidationCallbackService:
                 run.status not in VALIDATION_RUN_TERMINAL_STATUSES
                 and not ensure_runtime_profile_supported(
                     run,
-                    supported_profiles=(
-                        ValidationRuntimeProfile.LEGACY,
-                        ValidationRuntimeProfile.ATTEMPT_LIFECYCLE_V1,
-                    ),
+                    supported_profiles=(ValidationRuntimeProfile.ATTEMPT_LIFECYCLE_V1,),
                     operation="process_validation_callback",
                     sender=self.__class__,
                 )
@@ -266,14 +263,14 @@ class ValidationCallbackService:
         run: ValidationRun,
     ) -> Response:
         """
-        Ensure exactly-once processing for callbacks with a callback_id.
+        Ensure idempotent processing for an attempt-bound callback.
 
         Cloud Tasks (and most message queues) guarantee at-least-once delivery,
         so duplicate callbacks are expected. This method uses a CallbackReceipt
         table as an idempotency ledger:
 
-        1. No callback_id → skip idempotency, process immediately.
-        2. New callback_id → create a PROCESSING receipt, process under a
+        1. Resolve the callback's execution attempt.
+        2. A new callback_id creates a PROCESSING receipt under a
            row-level lock so no concurrent request can duplicate the work.
         3. Existing receipt still PROCESSING → previous attempt crashed
            mid-flight (or hit a transient error), so retry.
@@ -286,42 +283,20 @@ class ValidationCallbackService:
         from validibot.validations.services.execution_attempts import (
             resolve_callback_attempt,
         )
-        from validibot.validations.services.runtime_profiles import (
-            get_runtime_profile_policy,
+
+        attempt = resolve_callback_attempt(
+            callback.callback_id,
+            run_id=run.pk,
         )
-
-        attempt = None
-        if get_runtime_profile_policy(run.runtime_profile).uses_execution_attempts:
-            attempt = resolve_callback_attempt(
-                callback.callback_id,
-                run_id=run.pk,
+        if attempt is None:
+            logger.warning(
+                "Rejected callback that was not bound to an execution attempt",
+                extra={"run_id": str(run.pk)},
             )
-            if attempt is None:
-                logger.warning(
-                    "Rejected callback that was not bound to an execution attempt",
-                    extra={"run_id": str(run.pk)},
-                )
-                return Response(
-                    {"error": "Callback does not identify a valid execution attempt"},
-                    status=status.HTTP_400_BAD_REQUEST,
-                )
-            if attempt.is_terminal:
-                return self._late_callback_response(callback, run)
-            current_step = run.current_step_run
-            if current_step is None or current_step.pk != attempt.step_run_id:
-                return self._late_callback_response(callback, run)
-
-        if not callback.callback_id:
-            run.refresh_from_db(fields=["status"])
-            if run.status in VALIDATION_RUN_TERMINAL_STATUSES:
-                return self._late_callback_response(callback, run)
-            return self._process_callback(
-                callback=callback,
-                run=run,
-                receipt=None,
-                attempt=attempt,
+            return Response(
+                {"error": "Callback does not identify a valid execution attempt"},
+                status=status.HTTP_400_BAD_REQUEST,
             )
-
         try:
             with transaction.atomic():
                 receipt, receipt_created = self._get_or_create_receipt(
@@ -331,10 +306,7 @@ class ValidationCallbackService:
                 )
 
                 if not receipt_created:
-                    if (
-                        attempt is not None
-                        and receipt.execution_attempt_id != attempt.pk
-                    ):
+                    if receipt.execution_attempt_id != attempt.pk:
                         logger.error(
                             "Callback receipt attempt binding mismatch",
                             extra={
@@ -382,6 +354,18 @@ class ValidationCallbackService:
                         callback.callback_id,
                     )
 
+                # A crash can leave a PROCESSING receipt after the attempt or
+                # logical step became terminal. Close that receipt and
+                # acknowledge the late delivery without touching output.
+                current_step = run.current_step_run
+                if (
+                    attempt.is_terminal
+                    or current_step is None
+                    or current_step.pk != attempt.step_run_id
+                ):
+                    self._mark_receipt_completed(callback, receipt, run)
+                    return self._late_callback_response(callback, run)
+
                 # Preserve the existing idempotent response above for a true
                 # duplicate receipt. For a new/dangling receipt, refresh the
                 # authoritative run before any storage read; if cancellation,
@@ -420,7 +404,7 @@ class ValidationCallbackService:
     def _get_or_create_receipt(
         callback: ValidationCallback,
         run: ValidationRun,
-        attempt=None,
+        attempt,
     ) -> tuple[CallbackReceipt, bool]:
         """
         Fetch an existing receipt under a row lock, or create a new one.
@@ -451,8 +435,8 @@ class ValidationCallbackService:
         *,
         callback: ValidationCallback,
         run: ValidationRun,
-        receipt: CallbackReceipt | None,
-        attempt=None,
+        receipt: CallbackReceipt,
+        attempt,
     ) -> Response:
         """
         Orchestrate the callback processing pipeline.
@@ -487,34 +471,32 @@ class ValidationCallbackService:
             # are left PROCESSING so the retry can re-attempt.
             if status.is_client_error(exc.status_code):
                 self._mark_receipt_rejected(callback, receipt, run)
-                if attempt is not None:
-                    from validibot.validations.constants import ExecutionAttemptState
-                    from validibot.validations.services.execution_attempts import (
-                        transition_execution_attempt,
-                    )
+                from validibot.validations.constants import ExecutionAttemptState
+                from validibot.validations.services.execution_attempts import (
+                    transition_execution_attempt,
+                )
 
-                    transition_execution_attempt(
-                        attempt.pk,
-                        ExecutionAttemptState.FAILED,
-                        last_error_code="callback_rejected",
-                        last_error=str(exc.detail),
-                    )
+                transition_execution_attempt(
+                    attempt.pk,
+                    ExecutionAttemptState.FAILED,
+                    last_error_code="callback_rejected",
+                    last_error=str(exc.detail),
+                )
             return Response(
                 {"error": exc.detail},
                 status=exc.status_code,
             )
 
-        if attempt is not None:
-            from validibot.validations.constants import ExecutionAttemptState
-            from validibot.validations.services.execution_attempts import (
-                transition_execution_attempt,
-            )
+        from validibot.validations.constants import ExecutionAttemptState
+        from validibot.validations.services.execution_attempts import (
+            transition_execution_attempt,
+        )
 
-            transition_execution_attempt(
-                attempt.pk,
-                ExecutionAttemptState.COMPLETED,
-                provider_finished_at=timezone.now(),
-            )
+        transition_execution_attempt(
+            attempt.pk,
+            ExecutionAttemptState.COMPLETED,
+            provider_finished_at=timezone.now(),
+        )
 
         self._mark_receipt_completed(callback, receipt, run)
 
@@ -1001,7 +983,7 @@ class ValidationCallbackService:
     @staticmethod
     def _mark_receipt_completed(
         callback: ValidationCallback,
-        receipt: CallbackReceipt | None,
+        receipt: CallbackReceipt,
         run: ValidationRun,
     ) -> None:
         """
@@ -1011,9 +993,6 @@ class ValidationCallbackService:
         A failure here is logged but does not fail the request — the run
         is already in a consistent state.
         """
-        if not callback.callback_id or not receipt:
-            return
-
         try:
             receipt.status = CallbackReceiptStatus.COMPLETED
             receipt.validation_run = run
@@ -1033,7 +1012,7 @@ class ValidationCallbackService:
     @staticmethod
     def _mark_receipt_rejected(
         callback: ValidationCallback,
-        receipt: CallbackReceipt | None,
+        receipt: CallbackReceipt,
         run: ValidationRun,
     ) -> None:
         """
@@ -1045,9 +1024,6 @@ class ValidationCallbackService:
         doomed processing. A failure to update the receipt is logged but does
         not change the response — the error status is already being returned.
         """
-        if not callback.callback_id or not receipt:
-            return
-
         try:
             receipt.status = CallbackReceiptStatus.REJECTED
             receipt.validation_run = run

--- a/validibot/validations/services/validation_run.py
+++ b/validibot/validations/services/validation_run.py
@@ -42,7 +42,6 @@ from typing import Any
 
 from attr import dataclass
 from attr import field
-from django.conf import settings
 from django.db import transaction
 from django.utils import timezone
 from django.utils.translation import gettext as _
@@ -54,7 +53,6 @@ from validibot.validations.constants import VALIDATION_RUN_TERMINAL_STATUSES
 from validibot.validations.constants import StepStatus
 from validibot.validations.constants import ValidationRunSource
 from validibot.validations.constants import ValidationRunStatus
-from validibot.validations.constants import ValidationRuntimeProfile
 from validibot.validations.exceptions import OrgPolicyDeniedError
 from validibot.validations.models import ValidationRun
 from validibot.validations.models import ValidationRunSummary
@@ -96,7 +94,7 @@ def cancel_active_execution(run: ValidationRun) -> bool | None:
     The caller must commit the run's logical terminal state before invoking
     this helper. Provider APIs and PostgreSQL cannot share a transaction, so a
     provider failure is logged and returned without reopening the run. ``None``
-    means the legacy run has no addressable execution identity.
+    means the active step has no addressable execution identity.
     """
     step_run = (
         ValidationStepRun.objects.filter(
@@ -203,13 +201,6 @@ def fence_active_execution_attempt(
     error_message: str,
 ) -> None:
     """Terminally fence an attempt inside the caller's run transaction."""
-    from validibot.validations.services.runtime_profiles import (
-        get_runtime_profile_policy,
-    )
-
-    if not get_runtime_profile_policy(run.runtime_profile).uses_execution_attempts:
-        return
-
     step_run = (
         ValidationStepRun.objects.filter(
             validation_run=run,
@@ -379,24 +370,15 @@ class ValidationRunService:
             output_expires_at = timezone.now() + retention_delta
 
         run_extra = dict(extra or {})
-        requested_profile = run_extra.pop(
-            "runtime_profile",
-            getattr(
-                settings,
-                "VALIDATION_RUNTIME_PROFILE",
-                ValidationRuntimeProfile.LEGACY,
-            ),
-        )
-        from validibot.validations.services.runtime_profiles import (
-            is_runtime_profile_writer_enabled,
-        )
-
-        if not is_runtime_profile_writer_enabled(requested_profile):
-            msg = (
-                "This release creates LEGACY validation runs only; "
-                f"runtime profile {requested_profile!r} is reader-only."
-            )
+        # Runtime semantics are application-owned, not caller- or
+        # operator-selectable. Reject an override explicitly rather than
+        # silently hiding a caller that is trying to restore a second engine.
+        if "runtime_profile" in run_extra:
+            msg = "runtime_profile is selected by the application"
             raise ValueError(msg)
+        from validibot.validations.services.runtime_profiles import (
+            NEW_RUN_RUNTIME_PROFILE,
+        )
 
         with transaction.atomic():
             validation_run = ValidationRun.objects.create(
@@ -407,7 +389,7 @@ class ValidationRunService:
                 or getattr(workflow, "project", None),
                 user=run_user,
                 status=ValidationRunStatus.PENDING,
-                runtime_profile=requested_profile,
+                runtime_profile=NEW_RUN_RUNTIME_PROFILE,
                 source=source,
                 output_retention_policy=output_retention_policy,
                 output_expires_at=output_expires_at,

--- a/validibot/validations/tests/factories.py
+++ b/validibot/validations/tests/factories.py
@@ -213,7 +213,7 @@ class ValidationRunFactory(DjangoModelFactory):
     project = factory.LazyAttribute(lambda o: o.submission.project)
     user = factory.LazyAttribute(lambda o: o.submission.user)
     status = ValidationRunStatus.PENDING
-    runtime_profile = ValidationRuntimeProfile.LEGACY
+    runtime_profile = ValidationRuntimeProfile.ATTEMPT_LIFECYCLE_V1
     source = ValidationRunSource.LAUNCH_PAGE
 
 
@@ -232,7 +232,7 @@ class ValidationStepRunFactory(DjangoModelFactory):
 
 
 class ExecutionAttemptFactory(DjangoModelFactory):
-    """Build an attempt attached to an attempt-profile run for lifecycle tests."""
+    """Build a durable attempt attached to its validation step run."""
 
     class Meta:
         model = ExecutionAttempt
@@ -301,6 +301,12 @@ class CallbackReceiptFactory(DjangoModelFactory):
 
     callback_id = factory.Sequence(lambda n: f"cb-uuid-{n}")
     validation_run = factory.SubFactory(ValidationRunFactory)
+    execution_attempt = factory.LazyAttribute(
+        lambda obj: ExecutionAttemptFactory(
+            step_run__validation_run=obj.validation_run,
+            state=ExecutionAttemptState.COMPLETED,
+        ),
+    )
     status = CallbackReceiptStatus.COMPLETED
     result_uri = factory.LazyAttribute(
         lambda o: f"gs://bucket/runs/{o.validation_run.id}/output.json"

--- a/validibot/validations/tests/services/test_execution_backends.py
+++ b/validibot/validations/tests/services/test_execution_backends.py
@@ -50,7 +50,6 @@ from validibot.submissions.tests.factories import SubmissionFactory
 from validibot.users.tests.factories import OrganizationFactory
 from validibot.validations.constants import ExecutionAttemptState
 from validibot.validations.constants import Severity
-from validibot.validations.constants import ValidationRuntimeProfile
 from validibot.validations.constants import ValidationType
 from validibot.validations.services.cloud_run.envelope_builder import (
     build_energyplus_input_envelope,
@@ -77,10 +76,7 @@ from validibot.workflows.tests.factories import WorkflowStepFactory
 # ==============================================================================
 
 
-def _make_execution_request(
-    *,
-    runtime_profile: ValidationRuntimeProfile = ValidationRuntimeProfile.LEGACY,
-) -> ExecutionRequest:
+def _make_execution_request() -> ExecutionRequest:
     """Build an ExecutionRequest from real Django model instances.
 
     Creates the full model graph (Org → Workflow → ValidationRun → Step)
@@ -106,7 +102,6 @@ def _make_execution_request(
         submission=submission,
         workflow=workflow,
         org=org,
-        runtime_profile=runtime_profile,
     )
     # Also create a step run so validation_run.current_step_run works
     ValidationStepRunFactory(
@@ -238,16 +233,15 @@ class TestExecutionResponse:
         assert response.error_message is None
         assert response.execution_status is None
 
-    def test_execution_status_addition_preserves_legacy_positional_arguments(self):
-        """Older integrations must not reinterpret their third argument.
+    def test_execution_status_preserves_positional_field_order(self):
+        """The third positional argument must remain the output envelope.
 
-        ``execution_status`` is an additive reader-first field. Appending it to
-        the dataclass keeps a positional ``output_envelope`` argument in its
-        historical slot instead of silently treating the envelope as a status.
+        Keeping ``execution_status`` after ``output_envelope`` prevents a
+        positional envelope argument from being interpreted as a status.
         """
         envelope = object()
 
-        response = ExecutionResponse("exec-legacy", True, envelope)  # noqa: FBT003
+        response = ExecutionResponse("exec-positional", True, envelope)  # noqa: FBT003
 
         assert response.output_envelope is envelope
         assert response.execution_status is None
@@ -609,9 +603,7 @@ class TestDockerComposeExecutionBackend:
         pending response keeps the run available to the watchdog while the
         durable attempt prevents task redelivery from starting another copy.
         """
-        request = _make_execution_request(
-            runtime_profile=ValidationRuntimeProfile.ATTEMPT_LIFECYCLE_V1
-        )
+        request = _make_execution_request()
         attempt = ExecutionAttemptFactory(
             step_run=request.run.current_step_run,
             state=ExecutionAttemptState.PENDING,

--- a/validibot/validations/tests/test_api/test_callback_assertions.py
+++ b/validibot/validations/tests/test_api/test_callback_assertions.py
@@ -11,7 +11,6 @@ These tests verify that:
 3. Failure messages are generated for failed assertions
 """
 
-import uuid
 from unittest.mock import MagicMock
 from unittest.mock import patch
 
@@ -27,6 +26,8 @@ from validibot.validations.constants import StepStatus
 from validibot.validations.constants import ValidationRunStatus
 from validibot.validations.constants import ValidationType
 from validibot.validations.models import ValidationFinding
+from validibot.validations.services.execution_attempts import build_attempt_callback_id
+from validibot.validations.tests.factories import ExecutionAttemptFactory
 from validibot.validations.tests.factories import RulesetAssertionFactory
 from validibot.validations.tests.factories import RulesetFactory
 from validibot.validations.tests.factories import StepIODefinitionFactory
@@ -85,6 +86,11 @@ class CallbackAssertionEvaluationTests(TestCase):
             step_order=self.step.order,
             status=StepStatus.RUNNING,
         )
+        self.attempt = ExecutionAttemptFactory(
+            step_run=self.step_run,
+            state="RUNNING",
+        )
+        self.callback_id = build_attempt_callback_id(self.attempt)
 
     def _make_mock_envelope(
         self,
@@ -178,7 +184,7 @@ class CallbackAssertionEvaluationTests(TestCase):
             metrics={"site_eui_kwh_m2": 75},
         )
 
-        callback_id = str(uuid.uuid4())
+        callback_id = self.callback_id
         response = self.client.post(
             self.callback_url,
             data={
@@ -229,7 +235,7 @@ class CallbackAssertionEvaluationTests(TestCase):
             metrics={"site_eui_kwh_m2": 75},
         )
 
-        callback_id = str(uuid.uuid4())
+        callback_id = self.callback_id
         response = self.client.post(
             self.callback_url,
             data={
@@ -294,7 +300,7 @@ class CallbackAssertionEvaluationTests(TestCase):
             messages=[mock_message],
         )
 
-        callback_id = str(uuid.uuid4())
+        callback_id = self.callback_id
         response = self.client.post(
             self.callback_url,
             data={
@@ -375,6 +381,10 @@ class CallbackAssertionEvaluationTests(TestCase):
             step_order=system_step.order,
             status=StepStatus.RUNNING,
         )
+        system_attempt = ExecutionAttemptFactory(
+            step_run=system_step_run,
+            state="RUNNING",
+        )
 
         mock_message = MagicMock()
         mock_message.text = "** Severe ** non-fatal EnergyPlus message"
@@ -388,7 +398,7 @@ class CallbackAssertionEvaluationTests(TestCase):
             run_id=system_run.id,
         )
 
-        callback_id = str(uuid.uuid4())
+        callback_id = build_attempt_callback_id(system_attempt)
         response = self.client.post(
             self.callback_url,
             data={
@@ -444,7 +454,7 @@ class CallbackAssertionEvaluationTests(TestCase):
             metrics={"site_eui_kwh_m2": 75},
         )
 
-        callback_id = str(uuid.uuid4())
+        callback_id = self.callback_id
         response = self.client.post(
             self.callback_url,
             data={
@@ -494,7 +504,7 @@ class CallbackAssertionEvaluationTests(TestCase):
             metrics={"site_eui_kwh_m2": 75},
         )
 
-        callback_id = str(uuid.uuid4())
+        callback_id = self.callback_id
         response = self.client.post(
             self.callback_url,
             data={
@@ -551,7 +561,7 @@ class CallbackAssertionEvaluationTests(TestCase):
             metrics={"site_eui_kwh_m2": 75},
         )
 
-        callback_id = str(uuid.uuid4())
+        callback_id = self.callback_id
         response = self.client.post(
             self.callback_url,
             data={

--- a/validibot/validations/tests/test_api/test_callback_completion.py
+++ b/validibot/validations/tests/test_api/test_callback_completion.py
@@ -9,7 +9,6 @@ These tests cover correctness concerns beyond basic idempotency:
   callback request path (purge is queued for the scheduled purge worker).
 """
 
-import uuid
 from unittest.mock import MagicMock
 from unittest.mock import patch
 
@@ -28,6 +27,8 @@ from validibot.validations.constants import StepStatus
 from validibot.validations.constants import ValidationRunStatus
 from validibot.validations.constants import ValidationType
 from validibot.validations.models import ValidationRunSummary
+from validibot.validations.services.execution_attempts import build_attempt_callback_id
+from validibot.validations.tests.factories import ExecutionAttemptFactory
 from validibot.validations.tests.factories import ValidationFindingFactory
 from validibot.validations.tests.factories import ValidationRunFactory
 from validibot.validations.tests.factories import ValidationStepRunFactory
@@ -96,6 +97,11 @@ class CallbackCompletionTestCase(TestCase):
                 "execution_bundle_uri": "gs://bucket/runs/org/run",
             },
         )
+        self.attempt = ExecutionAttemptFactory(
+            step_run=self.step_run2,
+            state="RUNNING",
+            execution_bundle_uri="gs://bucket/runs/org/run",
+        )
 
         ValidationFindingFactory(
             validation_step_run=self.step_run1,
@@ -149,7 +155,7 @@ class CallbackCompletionTestCase(TestCase):
         """
         mock_download.return_value = self._make_mock_envelope()
 
-        callback_id = str(uuid.uuid4())
+        callback_id = build_attempt_callback_id(self.attempt)
         response = self.client.post(
             self.callback_url,
             data={

--- a/validibot/validations/tests/test_api/test_callback_idempotency.py
+++ b/validibot/validations/tests/test_api/test_callback_idempotency.py
@@ -23,6 +23,8 @@ from validibot.validations.constants import StepStatus
 from validibot.validations.constants import ValidationRunStatus
 from validibot.validations.constants import ValidationType
 from validibot.validations.models import CallbackReceipt
+from validibot.validations.services.execution_attempts import build_attempt_callback_id
+from validibot.validations.tests.factories import ExecutionAttemptFactory
 from validibot.validations.tests.factories import ValidationRunFactory
 from validibot.validations.tests.factories import ValidationStepRunFactory
 from validibot.validations.tests.factories import ValidatorFactory
@@ -62,6 +64,11 @@ class CallbackIdempotencyTestCase(TestCase):
             workflow_step=self.workflow_step,
             status=StepStatus.RUNNING,
         )
+        self.attempt = ExecutionAttemptFactory(
+            step_run=self.step_run,
+            state="RUNNING",
+        )
+        self.callback_id = build_attempt_callback_id(self.attempt)
 
         self.callback_url = "/api/v1/validation-callbacks/"
 
@@ -104,7 +111,7 @@ class CallbackIdempotencyTestCase(TestCase):
         """Test that the first callback with a callback_id is processed."""
         mock_download.return_value = self._make_mock_envelope()
 
-        callback_id = str(uuid.uuid4())
+        callback_id = self.callback_id
         payload = {
             "run_id": str(self.run.id),
             "callback_id": callback_id,
@@ -148,7 +155,7 @@ class CallbackIdempotencyTestCase(TestCase):
         mock_envelope.validator.id = str(uuid.uuid4())
         mock_download.return_value = mock_envelope
 
-        callback_id = str(uuid.uuid4())
+        callback_id = self.callback_id
         payload = {
             "run_id": str(self.run.id),
             "callback_id": callback_id,
@@ -168,17 +175,16 @@ class CallbackIdempotencyTestCase(TestCase):
     def test_rejected_callback_retry_short_circuits(self, mock_download):
         """A redelivery of a permanently REJECTED callback must NOT reprocess.
 
-        Once a callback is REJECTED (terminal), a Cloud Tasks redelivery should
-        hit the idempotency guard and return a cached 200 ("already rejected")
-        WITHOUT re-running processing — stopping the retry storm on a callback
-        that can never succeed. We prove no reprocessing by asserting
+        Once a callback is REJECTED (terminal), a Cloud Tasks redelivery hits
+        the receipt before terminal-attempt handling and returns a cached 200
+        without re-running processing. We prove that by asserting
         download_envelope is not called a second time.
         """
         mock_envelope = self._make_mock_envelope()
         mock_envelope.validator.id = str(uuid.uuid4())
         mock_download.return_value = mock_envelope
 
-        callback_id = str(uuid.uuid4())
+        callback_id = self.callback_id
         payload = {
             "run_id": str(self.run.id),
             "callback_id": callback_id,
@@ -208,7 +214,7 @@ class CallbackIdempotencyTestCase(TestCase):
         """Test that duplicate callbacks with same callback_id are not reprocessed."""
         mock_download.return_value = self._make_mock_envelope()
 
-        callback_id = str(uuid.uuid4())
+        callback_id = self.callback_id
         payload = {
             "run_id": str(self.run.id),
             "callback_id": callback_id,
@@ -250,8 +256,8 @@ class CallbackIdempotencyTestCase(TestCase):
 
     @override_settings(APP_IS_WORKER=True, ROOT_URLCONF="config.urls_worker")
     @patch("validibot.validations.services.validation_callback.download_envelope")
-    def test_callback_without_id_still_processed(self, mock_download):
-        """Test that callbacks without callback_id are processed (no idempotency)."""
+    def test_callback_without_attempt_id_is_rejected(self, mock_download):
+        """A callback without durable attempt identity must never mutate a run."""
         mock_download.return_value = self._make_mock_envelope()
 
         payload = {
@@ -267,24 +273,25 @@ class CallbackIdempotencyTestCase(TestCase):
             format="json",
         )
 
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.data["message"], "Callback processed successfully")
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(
+            response.data["error"],
+            "Callback does not identify a valid execution attempt",
+        )
 
         # No receipt created when callback_id is missing
         self.assertEqual(CallbackReceipt.objects.count(), 0)
 
     @override_settings(APP_IS_WORKER=True, ROOT_URLCONF="config.urls_worker")
     @patch("validibot.validations.services.validation_callback.download_envelope")
-    def test_different_callback_ids_processed_separately(self, mock_download):
-        """Test that different callback_ids are processed independently.
+    def test_different_attempt_callbacks_are_processed_separately(self, mock_download):
+        """Callbacks for distinct attempts are processed independently.
 
-        Each callback_id creates its own receipt. Sending two callbacks with
-        different callback_ids should create two separate receipts, not trigger
-        idempotent replay.
+        Each provider launch has its own durable callback identity and receipt.
         """
         mock_download.return_value = self._make_mock_envelope()
 
-        callback_id_1 = str(uuid.uuid4())
+        callback_id_1 = self.callback_id
 
         # First callback
         payload1 = {
@@ -307,11 +314,12 @@ class CallbackIdempotencyTestCase(TestCase):
             workflow=run2.workflow,
             validator=self.validator,
         )
-        ValidationStepRunFactory(
+        step_run2 = ValidationStepRunFactory(
             validation_run=run2,
             workflow_step=workflow_step2,
             status=StepStatus.RUNNING,
         )
+        attempt2 = ExecutionAttemptFactory(step_run=step_run2, state="RUNNING")
 
         # Update mock envelope for run2
         mock_envelope2 = self._make_mock_envelope()
@@ -320,7 +328,7 @@ class CallbackIdempotencyTestCase(TestCase):
         mock_envelope2.workflow.step_id = str(workflow_step2.id)
         mock_download.return_value = mock_envelope2
 
-        callback_id_2 = str(uuid.uuid4())
+        callback_id_2 = build_attempt_callback_id(attempt2)
 
         # Second callback with different callback_id
         payload2 = {
@@ -379,7 +387,7 @@ class CallbackIdempotencyTestCase(TestCase):
         # First call: simulate processor failure by throwing exception
         mock_download.side_effect = Exception("Simulated GCS download failure")
 
-        callback_id = str(uuid.uuid4())
+        callback_id = self.callback_id
         payload = {
             "run_id": str(self.run.id),
             "callback_id": callback_id,
@@ -426,12 +434,12 @@ class CallbackIdempotencyTestCase(TestCase):
         Test that callbacks with terminal receipt status are NOT retried.
 
         Once a callback has been successfully processed (terminal status),
-        subsequent callbacks with the same callback_id should return the
-        idempotent_replayed response, not reprocess.
+        subsequent callbacks with the same callback_id return the cached
+        receipt response rather than reprocessing output.
         """
         mock_download.return_value = self._make_mock_envelope()
 
-        callback_id = str(uuid.uuid4())
+        callback_id = self.callback_id
         payload = {
             "run_id": str(self.run.id),
             "callback_id": callback_id,
@@ -455,7 +463,7 @@ class CallbackIdempotencyTestCase(TestCase):
         # Reset mock to track if it gets called
         mock_download.reset_mock()
 
-        # Second attempt - should return idempotent response without reprocessing
+        # Second attempt returns the cached receipt without reprocessing.
         response2 = self.client.post(
             self.callback_url,
             data=payload,
@@ -481,6 +489,10 @@ class CallbackReceiptModelTestCase(TestCase):
             user=self.user,
             status=ValidationRunStatus.RUNNING,
         )
+        self.attempt = ExecutionAttemptFactory(
+            step_run__validation_run=self.run,
+            state="RUNNING",
+        )
 
     def test_callback_id_unique_constraint(self):
         """Test that callback_id must be unique."""
@@ -493,6 +505,7 @@ class CallbackReceiptModelTestCase(TestCase):
         CallbackReceipt.objects.create(
             callback_id=callback_id,
             validation_run=self.run,
+            execution_attempt=self.attempt,
             status=CallbackReceiptStatus.COMPLETED,
         )
 
@@ -501,6 +514,7 @@ class CallbackReceiptModelTestCase(TestCase):
             CallbackReceipt.objects.create(
                 callback_id=callback_id,
                 validation_run=self.run,
+                execution_attempt=self.attempt,
                 status=CallbackReceiptStatus.COMPLETED,
             )
 
@@ -510,6 +524,7 @@ class CallbackReceiptModelTestCase(TestCase):
         receipt = CallbackReceipt.objects.create(
             callback_id=callback_id,
             validation_run=self.run,
+            execution_attempt=self.attempt,
             status=CallbackReceiptStatus.COMPLETED,
         )
 
@@ -524,6 +539,7 @@ class CallbackReceiptModelTestCase(TestCase):
         receipt = CallbackReceipt.objects.create(
             callback_id=callback_id,
             validation_run=self.run,
+            execution_attempt=self.attempt,
             status=CallbackReceiptStatus.COMPLETED,
             result_uri=result_uri,
         )

--- a/validibot/validations/tests/test_api/test_callback_result_uri_allowlist.py
+++ b/validibot/validations/tests/test_api/test_callback_result_uri_allowlist.py
@@ -35,6 +35,8 @@ from validibot.users.tests.factories import UserFactory
 from validibot.validations.constants import StepStatus
 from validibot.validations.constants import ValidationRunStatus
 from validibot.validations.constants import ValidationType
+from validibot.validations.services.execution_attempts import build_attempt_callback_id
+from validibot.validations.tests.factories import ExecutionAttemptFactory
 from validibot.validations.tests.factories import ValidationRunFactory
 from validibot.validations.tests.factories import ValidationStepRunFactory
 from validibot.validations.tests.factories import ValidatorFactory
@@ -87,6 +89,11 @@ class CallbackResultUriAllowlistTestCase(TestCase):
             step_order=self.step.order,
             status=StepStatus.RUNNING,
         )
+        self.attempt = ExecutionAttemptFactory(
+            step_run=self.step_run,
+            state="RUNNING",
+        )
+        self.callback_id = build_attempt_callback_id(self.attempt)
 
         # The deterministic, per-run prefix the launcher writes bundles under.
         self.run_prefix = f"runs/{self.run.org_id}/{self.run.id}"
@@ -125,6 +132,7 @@ class CallbackResultUriAllowlistTestCase(TestCase):
             self.callback_url,
             data={
                 "run_id": str(self.run.id),
+                "callback_id": self.callback_id,
                 "status": "success",
                 "result_uri": hostile_uri,
             },
@@ -154,6 +162,7 @@ class CallbackResultUriAllowlistTestCase(TestCase):
             self.callback_url,
             data={
                 "run_id": str(self.run.id),
+                "callback_id": self.callback_id,
                 "status": "success",
                 "result_uri": legit_uri,
             },

--- a/validibot/validations/tests/test_callback_terminal_fencing.py
+++ b/validibot/validations/tests/test_callback_terminal_fencing.py
@@ -17,8 +17,11 @@ from validibot_shared.validations.envelopes import ValidationStatus
 from validibot.validations.constants import StepStatus
 from validibot.validations.constants import ValidationRunStatus
 from validibot.validations.models import ValidationRun
+from validibot.validations.services.execution_attempts import build_attempt_callback_id
 from validibot.validations.services.validation_callback import ValidationCallbackService
+from validibot.validations.tests.factories import ExecutionAttemptFactory
 from validibot.validations.tests.factories import ValidationRunFactory
+from validibot.validations.tests.factories import ValidationStepRunFactory
 
 
 @pytest.mark.django_db
@@ -40,13 +43,21 @@ class TestCallbackTerminalFencing:
         outcome and avoids trusting stale output after the deadline.
         """
         run = ValidationRunFactory(status=terminal_status)
+        step_run = ValidationStepRunFactory(
+            validation_run=run,
+            status=StepStatus.RUNNING,
+        )
+        attempt = ExecutionAttemptFactory(
+            step_run=step_run,
+            state="RUNNING",
+        )
         service = ValidationCallbackService()
 
         with patch.object(service, "_process_callback") as process:
             response = service.process(
                 payload={
                     "run_id": str(run.id),
-                    "callback_id": f"late-{run.id}",
+                    "callback_id": build_attempt_callback_id(attempt),
                     "status": "success",
                     "result_uri": "gs://bucket/output.json",
                 }

--- a/validibot/validations/tests/test_execution_attempts.py
+++ b/validibot/validations/tests/test_execution_attempts.py
@@ -1,10 +1,9 @@
-"""Tests for the reader-first execution-attempt aggregate and state graph.
+"""Tests for the execution-attempt aggregate and state graph.
 
 An attempt is the durable identity for one concrete provider launch.  These
-tests focus on invariants that must hold before production writers are enabled:
-one active attempt per logical step, unique provider identities, profile-bound
-contracts, monotonic terminal state, and profile-aware identity lookup that
-never falls back to stale legacy JSON.
+tests focus on its core invariants: one active attempt per logical step, unique
+provider identities, profile-bound contracts, monotonic terminal state, and
+provider identity lookup that never falls back to mutable step output.
 """
 
 from itertools import product
@@ -16,7 +15,6 @@ from django.db import transaction
 
 from validibot.validations.constants import ExecutionAttemptState
 from validibot.validations.constants import ExecutionContractVersion
-from validibot.validations.constants import ValidationRuntimeProfile
 from validibot.validations.models import CallbackReceipt
 from validibot.validations.models import ExecutionAttempt
 from validibot.validations.services.execution_attempts import (
@@ -36,7 +34,6 @@ from validibot.validations.services.execution_attempts import (
 )
 from validibot.validations.tests.factories import CallbackReceiptFactory
 from validibot.validations.tests.factories import ExecutionAttemptFactory
-from validibot.validations.tests.factories import ValidationRunFactory
 from validibot.validations.tests.factories import ValidationStepRunFactory
 
 EXPECTED_ATTEMPT_COUNT = 2
@@ -107,28 +104,14 @@ class TestExecutionAttemptModel:
         with pytest.raises(ValidationError, match="contract must match"):
             attempt.full_clean()
 
-    def test_legacy_run_rejects_attempt_during_model_validation(self):
-        """A nullable attempt table must not become an implicit profile switch."""
-        legacy_step = ValidationStepRunFactory(
-            validation_run=ValidationRunFactory(
-                runtime_profile=ValidationRuntimeProfile.LEGACY
-            )
-        )
-        attempt = ExecutionAttemptFactory(step_run=legacy_step)
-
-        with pytest.raises(ValidationError, match="Legacy runs cannot contain"):
-            attempt.full_clean()
-
-    def test_callback_receipt_link_is_additive_for_legacy_and_attempt_modes(self):
-        """Legacy receipts stay valid while new receipts can bind to one attempt."""
-        legacy_receipt = CallbackReceiptFactory()
+    def test_callback_receipt_requires_attempt_identity(self):
+        """Every accepted callback must remain attributable to its provider work."""
         attempt = ExecutionAttemptFactory(state=ExecutionAttemptState.RUNNING)
         attempt_receipt = CallbackReceiptFactory(
             validation_run=attempt.step_run.validation_run,
             execution_attempt=attempt,
         )
 
-        assert legacy_receipt.execution_attempt_id is None
         assert attempt_receipt.execution_attempt_id == attempt.id
 
     def test_callback_receipt_attempt_must_belong_to_same_run(self):
@@ -254,26 +237,10 @@ class TestExecutionAttemptTransitions:
 
 @pytest.mark.django_db
 class TestProviderExecutionIdentity:
-    """Read provider identity only from the source selected by run profile."""
+    """Read provider identity only from durable execution-attempt columns."""
 
-    def test_legacy_profile_reads_existing_step_output(self):
-        """Stage 1 must preserve cancellation for every existing run."""
-        step_run = ValidationStepRunFactory(
-            output={
-                "execution_name": "legacy-execution",
-                "execution_bundle_uri": "gs://bucket/legacy",
-            }
-        )
-
-        identity = resolve_provider_execution_identity(step_run)
-
-        assert identity is not None
-        assert identity.execution_id == "legacy-execution"
-        assert identity.execution_bundle_uri == "gs://bucket/legacy"
-        assert identity.attempt is None
-
-    def test_attempt_profile_reads_attempt_row(self):
-        """Attempt-mode cancellation must use durable columns, not mutable JSON."""
+    def test_provider_identity_reads_attempt_row(self):
+        """Cancellation must use durable columns rather than mutable step JSON."""
         attempt = ExecutionAttemptFactory(
             state=ExecutionAttemptState.RUNNING,
             provider_execution_id="attempt-execution",
@@ -289,12 +256,9 @@ class TestProviderExecutionIdentity:
         assert identity.execution_bundle_uri == "gs://bucket/attempt"
         assert identity.attempt == attempt
 
-    def test_attempt_profile_never_falls_back_to_legacy_json(self):
-        """Missing attempt identity must not permit stale legacy fallback."""
+    def test_provider_identity_never_falls_back_to_step_output(self):
+        """Missing attempt identity must not permit stale JSON fallback."""
         step_run = ValidationStepRunFactory(
-            validation_run__runtime_profile=(
-                ValidationRuntimeProfile.ATTEMPT_LIFECYCLE_V1
-            ),
             output={"execution_name": "stale-legacy-execution"},
         )
 

--- a/validibot/validations/tests/test_gcp_reconciliation.py
+++ b/validibot/validations/tests/test_gcp_reconciliation.py
@@ -58,7 +58,7 @@ def _mock_run(*, step_output=None, minutes_ago=45, status=ValidationRunStatus.RU
     run.id = uuid.uuid4()
     run.pk = run.id
     run.status = status
-    run.runtime_profile = ValidationRuntimeProfile.LEGACY
+    run.runtime_profile = ValidationRuntimeProfile.ATTEMPT_LIFECYCLE_V1
     run.started_at = timezone.now() - timedelta(minutes=minutes_ago)
     run.ended_at = None
     run.duration_ms = None
@@ -69,11 +69,28 @@ def _mock_run(*, step_output=None, minutes_ago=45, status=ValidationRunStatus.RU
 
 
 def _mock_step_run(*, output=None):
-    """Create a mock ValidationStepRun."""
+    """Create a step run whose provider identity lives on an attempt."""
+    provider_data = output or {}
     step_run = MagicMock()
-    step_run.output = output or {}
+    step_run.output = {}
     step_run.status = StepStatus.RUNNING
-    step_run.validation_run.runtime_profile = ValidationRuntimeProfile.LEGACY
+    step_run.validation_run.runtime_profile = (
+        ValidationRuntimeProfile.ATTEMPT_LIFECYCLE_V1
+    )
+    attempt = MagicMock()
+    attempt.pk = uuid.uuid4()
+    attempt.provider_execution_id = provider_data.get("execution_name", "")
+    attempt.execution_bundle_uri = provider_data.get("execution_bundle_uri", "")
+    attempt.runner_type = "google_cloud_run"
+    active_attempt = attempt if attempt.provider_execution_id else None
+    active_queryset = (
+        step_run.execution_attempts.filter.return_value.order_by.return_value
+    )
+    active_queryset.first.return_value = active_attempt
+    step_run.execution_attempts.order_by.return_value.first.return_value = (
+        active_attempt
+    )
+    step_run.attempt = attempt
     return step_run
 
 
@@ -139,6 +156,7 @@ class TestReconcileStillRunningJob(SimpleTestCase):
         mock_backend.check_status.return_value = ExecutionResponse(
             execution_id="projects/p/locations/r/jobs/j/executions/e",
             is_complete=False,
+            execution_status=ExecutionStatus.RUNNING,
         )
         mock_backend_cls.return_value = mock_backend
 
@@ -190,7 +208,11 @@ class TestReconcileMarksFailed(SimpleTestCase):
             result = cmd._try_reconcile_gcp_run(run)
 
         assert result == "reconciled"
-        mock_mark_failed.assert_called_once_with(run, "Container OOM killed")
+        mock_mark_failed.assert_called_once_with(
+            run,
+            "Container OOM killed",
+            attempt=step_run.attempt,
+        )
 
     @patch(f"{CMD_PATH}.Command._is_gcp_deployment", return_value=True)
     @patch(GCP_BACKEND_PATH)
@@ -234,6 +256,7 @@ class TestReconcileMarksFailed(SimpleTestCase):
         mock_mark_failed.assert_called_once_with(
             run,
             "Cloud Run reported a failed execution without diagnostic details",
+            attempt=step_run.attempt,
         )
         mock_recover.assert_not_called()
 
@@ -243,7 +266,15 @@ class TestMarkRunFailedFromGCP(SimpleTestCase):
 
     @patch(f"{CMD_PATH}.transaction")
     @patch(f"{CMD_PATH}.ValidationRun")
-    def test_marks_run_as_failed(self, mock_run_model, mock_transaction):
+    @patch(
+        "validibot.validations.services.execution_attempts.transition_execution_attempt"
+    )
+    def test_marks_run_as_failed(
+        self,
+        mock_transition,
+        mock_run_model,
+        mock_transaction,
+    ):
         """Should lock the run and set FAILED status with error details."""
         locked_run = MagicMock()
         locked_run.status = ValidationRunStatus.RUNNING
@@ -257,8 +288,13 @@ class TestMarkRunFailedFromGCP(SimpleTestCase):
         mock_transaction.atomic.return_value.__exit__ = MagicMock(return_value=False)
 
         run = _mock_run()
+        attempt = MagicMock()
         cmd = Command()
-        cmd._mark_run_failed_from_gcp(run, "Container OOM killed")
+        cmd._mark_run_failed_from_gcp(
+            run,
+            "Container OOM killed",
+            attempt=attempt,
+        )
 
         assert locked_run.status == ValidationRunStatus.FAILED
         assert locked_run.error_category == ValidationRunErrorCategory.RUNTIME_ERROR
@@ -267,6 +303,7 @@ class TestMarkRunFailedFromGCP(SimpleTestCase):
         assert locked_run.ended_at is not None
         assert locked_run.duration_ms is not None
         locked_run.save.assert_called_once()
+        mock_transition.assert_called_once()
 
     @patch(f"{CMD_PATH}.transaction")
     @patch(f"{CMD_PATH}.ValidationRun")
@@ -282,8 +319,13 @@ class TestMarkRunFailedFromGCP(SimpleTestCase):
         mock_transaction.atomic.return_value.__exit__ = MagicMock(return_value=False)
 
         run = _mock_run()
+        attempt = MagicMock()
         cmd = Command()
-        cmd._mark_run_failed_from_gcp(run, "Container OOM killed")
+        cmd._mark_run_failed_from_gcp(
+            run,
+            "Container OOM killed",
+            attempt=attempt,
+        )
 
         # Should not have been modified
         locked_run.save.assert_not_called()
@@ -304,7 +346,7 @@ class TestReconcileRecoversLostCallback(SimpleTestCase):
         mock_backend.check_status.return_value = ExecutionResponse(
             execution_id="projects/p/locations/r/jobs/j/executions/e",
             is_complete=True,
-            # No error_message = job succeeded
+            execution_status=ExecutionStatus.SUCCEEDED,
         )
         mock_backend_cls.return_value = mock_backend
 
@@ -332,7 +374,7 @@ class TestReconcileRecoversLostCallback(SimpleTestCase):
         call_kwargs = mock_service.process.call_args[1]
         payload = call_kwargs["payload"]
         assert payload["run_id"] == str(run.id)
-        assert payload["callback_id"] == f"reconciliation-{run.id}"
+        assert payload["callback_id"] == (f"execution-attempt-{step_run.attempt.pk}")
         assert payload["result_uri"] == "gs://bucket/runs/org/run-id/output.json"
 
     @patch(f"{CMD_PATH}.Command._is_gcp_deployment", return_value=True)
@@ -346,6 +388,7 @@ class TestReconcileRecoversLostCallback(SimpleTestCase):
         mock_backend.check_status.return_value = ExecutionResponse(
             execution_id="projects/p/locations/r/jobs/j/executions/e",
             is_complete=True,
+            execution_status=ExecutionStatus.SUCCEEDED,
         )
         mock_backend_cls.return_value = mock_backend
 
@@ -377,6 +420,7 @@ class TestReconcileRecoversLostCallback(SimpleTestCase):
         mock_backend.check_status.return_value = ExecutionResponse(
             execution_id="projects/p/locations/r/jobs/j/executions/e",
             is_complete=True,
+            execution_status=ExecutionStatus.SUCCEEDED,
         )
         mock_backend_cls.return_value = mock_backend
 
@@ -452,6 +496,7 @@ class TestReconcileDryRun(SimpleTestCase):
         mock_backend.check_status.return_value = ExecutionResponse(
             execution_id="projects/p/locations/r/jobs/j/executions/e",
             is_complete=True,
+            execution_status=ExecutionStatus.SUCCEEDED,
         )
         mock_backend_cls.return_value = mock_backend
 
@@ -480,6 +525,7 @@ class TestReconcileDryRun(SimpleTestCase):
         mock_backend.check_status.return_value = ExecutionResponse(
             execution_id="projects/p/locations/r/jobs/j/executions/e",
             is_complete=True,
+            execution_status=ExecutionStatus.FAILED,
             error_message="OOM killed",
         )
         mock_backend_cls.return_value = mock_backend
@@ -543,6 +589,7 @@ class TestCommandHandle(SimpleTestCase):
         mock_backend.check_status.return_value = ExecutionResponse(
             execution_id="projects/p/locations/r/jobs/j/executions/e",
             is_complete=True,
+            execution_status=ExecutionStatus.SUCCEEDED,
         )
         mock_backend_cls.return_value = mock_backend
 
@@ -622,7 +669,7 @@ class TestCommandHandle(SimpleTestCase):
 
         locked_run = MagicMock()
         locked_run.status = ValidationRunStatus.RUNNING
-        locked_run.runtime_profile = ValidationRuntimeProfile.LEGACY
+        locked_run.runtime_profile = ValidationRuntimeProfile.ATTEMPT_LIFECYCLE_V1
         locked_run.started_at = run.started_at
         mock_run_model.objects.select_for_update.return_value.get.return_value = (
             locked_run
@@ -637,12 +684,16 @@ class TestCommandHandle(SimpleTestCase):
         cmd.style.SUCCESS = lambda x: x
         cmd.style.WARNING = lambda x: x
 
-        with patch.object(cmd, "_get_active_step_run", return_value=step_run):
+        with (
+            patch.object(cmd, "_get_active_step_run", return_value=step_run),
+            patch(f"{CMD_PATH}.fence_active_execution_attempt") as mock_fence,
+        ):
             cmd.handle(timeout_minutes=30, dry_run=False, batch_size=100)
 
         output = out.getvalue()
         assert locked_run.status == ValidationRunStatus.TIMED_OUT
         assert "Marked 1 stuck run(s) as TIMED_OUT" in output
+        mock_fence.assert_called_once()
         mock_cancel.assert_called_once_with(locked_run)
 
     @patch(f"{CMD_PATH}.ValidationRun")
@@ -667,7 +718,7 @@ class TestCommandHandle(SimpleTestCase):
         # Mock the atomic block and select_for_update
         locked_run = MagicMock()
         locked_run.status = ValidationRunStatus.RUNNING
-        locked_run.runtime_profile = ValidationRuntimeProfile.LEGACY
+        locked_run.runtime_profile = ValidationRuntimeProfile.ATTEMPT_LIFECYCLE_V1
         locked_run.started_at = run.started_at
         mock_run_model.objects.select_for_update.return_value.get.return_value = (
             locked_run
@@ -682,12 +733,14 @@ class TestCommandHandle(SimpleTestCase):
         cmd.style.SUCCESS = lambda x: x
         cmd.style.WARNING = lambda x: x
 
-        cmd.handle(timeout_minutes=30, dry_run=False, batch_size=100)
+        with patch(f"{CMD_PATH}.fence_active_execution_attempt") as mock_fence:
+            cmd.handle(timeout_minutes=30, dry_run=False, batch_size=100)
 
         # The locked run should have been updated to TIMED_OUT
         assert locked_run.status == ValidationRunStatus.TIMED_OUT
         assert locked_run.error_category == ValidationRunErrorCategory.TIMEOUT
         locked_run.save.assert_called_once()
+        mock_fence.assert_called_once()
         mock_cancel.assert_called_once_with(locked_run)
 
     @patch(f"{CMD_PATH}.ValidationRun")

--- a/validibot/validations/tests/test_run_cancellation.py
+++ b/validibot/validations/tests/test_run_cancellation.py
@@ -14,6 +14,7 @@ import pytest
 from validibot.validations.constants import StepStatus
 from validibot.validations.constants import ValidationRunStatus
 from validibot.validations.services.validation_run import ValidationRunService
+from validibot.validations.tests.factories import ExecutionAttemptFactory
 from validibot.validations.tests.factories import ValidationRunFactory
 from validibot.validations.tests.factories import ValidationStepRunFactory
 
@@ -37,10 +38,14 @@ class TestValidationRunCancellation:
         """
         execution_id = "projects/p/locations/r/jobs/j/executions/e"
         run = ValidationRunFactory(status=ValidationRunStatus.RUNNING)
-        ValidationStepRunFactory(
+        step_run = ValidationStepRunFactory(
             validation_run=run,
             status=StepStatus.RUNNING,
-            output={"execution_name": execution_id},
+        )
+        attempt = ExecutionAttemptFactory(
+            step_run=step_run,
+            state="RUNNING",
+            provider_execution_id=execution_id,
         )
         runner = MagicMock()
         runner.cancel.return_value = True
@@ -50,7 +55,9 @@ class TestValidationRunCancellation:
 
         assert canceled is True
         updated_run.refresh_from_db()
+        attempt.refresh_from_db()
         assert updated_run.status == ValidationRunStatus.CANCELED
+        assert attempt.state == "CANCELED"
         runner.cancel.assert_called_once_with(execution_id)
 
     @patch(RUNNER_FACTORY_PATH)
@@ -65,10 +72,14 @@ class TestValidationRunCancellation:
         failure as observable cleanup work rather than reopening the run.
         """
         run = ValidationRunFactory(status=ValidationRunStatus.RUNNING)
-        ValidationStepRunFactory(
+        step_run = ValidationStepRunFactory(
             validation_run=run,
             status=StepStatus.RUNNING,
-            output={"execution_name": "execution-123"},
+        )
+        attempt = ExecutionAttemptFactory(
+            step_run=step_run,
+            state="RUNNING",
+            provider_execution_id="execution-123",
         )
         runner = MagicMock()
         runner.cancel.return_value = False
@@ -78,4 +89,7 @@ class TestValidationRunCancellation:
 
         assert canceled is True
         run.refresh_from_db()
+        attempt.refresh_from_db()
         assert run.status == ValidationRunStatus.CANCELED
+        assert attempt.state == "CANCELED"
+        runner.cancel.assert_called_once_with("execution-123")

--- a/validibot/validations/tests/test_runtime_profile_routing.py
+++ b/validibot/validations/tests/test_runtime_profile_routing.py
@@ -31,7 +31,7 @@ RUNNER_FACTORY_PATH = "validibot.validations.services.runners.get_validator_runn
 
 @pytest.mark.django_db
 class TestRuntimeProfileRouting:
-    """Route attempt-mode work without falling back to legacy metadata."""
+    """Route execution work exclusively through durable attempt identity."""
 
     @patch("validibot.validations.signals.validation_run_finalized.send_robust")
     def test_orchestrator_accepts_attempt_profile(

--- a/validibot/validations/tests/test_runtime_profiles.py
+++ b/validibot/validations/tests/test_runtime_profiles.py
@@ -1,10 +1,9 @@
-"""Tests for immutable validation-run runtime profiles and rollout policy.
+"""Tests for immutable validation-run runtime profiles.
 
-Runtime profiles are the mixed-version boundary for the execution-integrity
-program.  These tests prove every accepted rung has one explicit policy, that
-writers remain legacy-only during the reader-first release, and that a handler
-which cannot interpret a run fences it instead of falling through to legacy
-execution.
+Runtime profiles version execution semantics without exposing an operator
+switch. These tests prove the application selects the attempt lifecycle for
+new runs, every active rung has one policy, and older handlers fence newer work
+instead of guessing how to interpret it.
 """
 
 from unittest.mock import patch
@@ -16,6 +15,7 @@ from validibot.validations.constants import ExecutionContractVersion
 from validibot.validations.constants import ValidationRunErrorCategory
 from validibot.validations.constants import ValidationRunStatus
 from validibot.validations.constants import ValidationRuntimeProfile
+from validibot.validations.services.runtime_profiles import NEW_RUN_RUNTIME_PROFILE
 from validibot.validations.services.runtime_profiles import (
     UNSUPPORTED_RUNTIME_PROFILE_ERROR,
 )
@@ -27,14 +27,11 @@ from validibot.validations.services.runtime_profiles import (
     ensure_runtime_profile_supported,
 )
 from validibot.validations.services.runtime_profiles import get_runtime_profile_policy
-from validibot.validations.services.runtime_profiles import (
-    is_runtime_profile_writer_enabled,
-)
 from validibot.validations.tests.factories import ValidationRunFactory
 
 
 class TestRuntimeProfilePolicy:
-    """Keep the four-rung rollout policy explicit and table-driven."""
+    """Keep the execution-semantics ladder explicit and table-driven."""
 
     def test_every_declared_profile_has_exactly_one_policy(self):
         """A new enum value must not silently inherit another profile's behavior."""
@@ -46,19 +43,11 @@ class TestRuntimeProfilePolicy:
         assert resolved == set(ValidationRuntimeProfile)
 
     @pytest.mark.parametrize(
-        ("profile", "contract", "attempts", "strict_io", "canonical_context"),
+        ("profile", "contract", "strict_io", "canonical_context"),
         [
-            (
-                ValidationRuntimeProfile.LEGACY,
-                ExecutionContractVersion.LEGACY_URI_V1,
-                False,
-                False,
-                False,
-            ),
             (
                 ValidationRuntimeProfile.ATTEMPT_LIFECYCLE_V1,
                 ExecutionContractVersion.LEGACY_URI_V1,
-                True,
                 False,
                 False,
             ),
@@ -66,13 +55,11 @@ class TestRuntimeProfilePolicy:
                 ValidationRuntimeProfile.ATTEMPT_STRICT_V1,
                 ExecutionContractVersion.STRICT_CONTENT_V1,
                 True,
-                True,
                 False,
             ),
             (
                 ValidationRuntimeProfile.ATTEMPT_CONTEXT_V1,
                 ExecutionContractVersion.STRICT_CONTENT_V1,
-                True,
                 True,
                 True,
             ),
@@ -82,7 +69,6 @@ class TestRuntimeProfilePolicy:
         self,
         profile,
         contract,
-        attempts,
         strict_io,
         canonical_context,
     ):
@@ -90,7 +76,6 @@ class TestRuntimeProfilePolicy:
         policy = get_runtime_profile_policy(profile)
 
         assert policy.contract_version == contract
-        assert policy.uses_execution_attempts is attempts
         assert policy.uses_strict_io is strict_io
         assert policy.uses_canonical_context is canonical_context
 
@@ -103,41 +88,41 @@ class TestRuntimeProfilePolicy:
                 expected = target_index in {current_index, current_index + 1}
                 assert can_advance_runtime_profile(current, target) is expected
 
-    def test_lifecycle_release_enables_only_completed_writer_rungs(self):
-        """Strict-I/O profiles remain reader-only until their ADRs complete."""
-        assert is_runtime_profile_writer_enabled(ValidationRuntimeProfile.LEGACY)
-        assert is_runtime_profile_writer_enabled(
-            ValidationRuntimeProfile.ATTEMPT_LIFECYCLE_V1
-        )
-        for profile in list(ValidationRuntimeProfile)[2:]:
-            assert not is_runtime_profile_writer_enabled(profile)
+    def test_application_selects_attempt_lifecycle_for_new_runs(self):
+        """Run semantics must come from code rather than operator configuration."""
+        assert NEW_RUN_RUNTIME_PROFILE == ValidationRuntimeProfile.ATTEMPT_LIFECYCLE_V1
 
     def test_unknown_profile_is_rejected(self):
         """Typos or newer unknown profiles must never be interpreted as legacy."""
         with pytest.raises(UnsupportedRuntimeProfileError):
             get_runtime_profile_policy("ATTEMPT_UNKNOWN_V9")
 
+    def test_retired_legacy_profile_is_rejected(self):
+        """Historical legacy rows must never re-enter the active execution path."""
+        with pytest.raises(UnsupportedRuntimeProfileError):
+            get_runtime_profile_policy("LEGACY")
+
 
 @pytest.mark.django_db
 class TestRuntimeProfilePersistence:
     """Protect a run's recorded execution semantics for its whole lifetime."""
 
-    def test_new_runs_default_to_legacy(self):
-        """The additive migration must leave existing production behavior unchanged."""
+    def test_new_runs_default_to_attempt_lifecycle(self):
+        """Direct model creation must use the one supported execution architecture."""
         run = ValidationRunFactory()
 
-        assert run.runtime_profile == ValidationRuntimeProfile.LEGACY
+        assert run.runtime_profile == ValidationRuntimeProfile.ATTEMPT_LIFECYCLE_V1
 
     def test_normal_model_save_cannot_reinterpret_an_existing_run(self):
         """Changing profile in place could route an in-flight callback incorrectly."""
         run = ValidationRunFactory()
-        run.runtime_profile = ValidationRuntimeProfile.ATTEMPT_LIFECYCLE_V1
+        run.runtime_profile = ValidationRuntimeProfile.ATTEMPT_STRICT_V1
 
         with pytest.raises(ValidationError, match="cannot be changed"):
             run.save(update_fields=["runtime_profile"])
 
         run.refresh_from_db()
-        assert run.runtime_profile == ValidationRuntimeProfile.LEGACY
+        assert run.runtime_profile == ValidationRuntimeProfile.ATTEMPT_LIFECYCLE_V1
 
     @patch("validibot.validations.signals.validation_run_finalized.send_robust")
     def test_unsupported_handler_fences_active_run_once(self, mock_finalized):
@@ -149,13 +134,13 @@ class TestRuntimeProfilePersistence:
 
         first_result = ensure_runtime_profile_supported(
             run,
-            supported_profiles=(ValidationRuntimeProfile.LEGACY,),
+            supported_profiles=(ValidationRuntimeProfile.ATTEMPT_STRICT_V1,),
             operation="test_handler",
             sender=self.__class__,
         )
         second_result = ensure_runtime_profile_supported(
             run,
-            supported_profiles=(ValidationRuntimeProfile.LEGACY,),
+            supported_profiles=(ValidationRuntimeProfile.ATTEMPT_STRICT_V1,),
             operation="test_handler",
             sender=self.__class__,
         )
@@ -171,12 +156,12 @@ class TestRuntimeProfilePersistence:
 
     @patch("validibot.validations.signals.validation_run_finalized.send_robust")
     def test_supported_handler_does_not_mutate_run(self, mock_finalized):
-        """The Stage 1 guard must be invisible to every normal legacy run."""
+        """The profile guard must be invisible to the current execution path."""
         run = ValidationRunFactory(status=ValidationRunStatus.RUNNING)
 
         supported = ensure_runtime_profile_supported(
             run,
-            supported_profiles=(ValidationRuntimeProfile.LEGACY,),
+            supported_profiles=(ValidationRuntimeProfile.ATTEMPT_LIFECYCLE_V1,),
             operation="test_handler",
             sender=self.__class__,
         )

--- a/validibot/validations/tests/test_validation_run_service.py
+++ b/validibot/validations/tests/test_validation_run_service.py
@@ -69,13 +69,15 @@ def test_launch_commits_run_before_enqueue(monkeypatch):
     validation_run = response.validation_run
     validation_run.refresh_from_db()
     assert validation_run.pk
-    assert validation_run.runtime_profile == ValidationRuntimeProfile.LEGACY
+    assert (
+        validation_run.runtime_profile == ValidationRuntimeProfile.ATTEMPT_LIFECYCLE_V1
+    )
     assert response.status in {status.HTTP_202_ACCEPTED, status.HTTP_201_CREATED}
 
 
 @pytest.mark.django_db
-def test_launch_accepts_completed_attempt_lifecycle_profile():
-    """The completed writer rung can be selected explicitly per new run."""
+def test_launch_does_not_allow_callers_to_select_runtime_profile():
+    """Caller metadata must not restore a second execution architecture."""
     org = OrganizationFactory()
     user = UserFactory()
     grant_role(user, org, RoleCode.EXECUTOR)
@@ -90,20 +92,15 @@ def test_launch_accepts_completed_attempt_lifecycle_profile():
     request = APIRequestFactory().post("/api/v1/workflows/start/")
     request.user = user
 
-    response = ValidationRunService().launch(
-        request=request,
-        org=org,
-        workflow=workflow,
-        submission=submission,
-        user_id=user.id,
-        extra={"runtime_profile": (ValidationRuntimeProfile.ATTEMPT_LIFECYCLE_V1)},
-    )
-
-    response.validation_run.refresh_from_db()
-    assert (
-        response.validation_run.runtime_profile
-        == ValidationRuntimeProfile.ATTEMPT_LIFECYCLE_V1
-    )
+    with pytest.raises(ValueError, match="selected by the application"):
+        ValidationRunService().launch(
+            request=request,
+            org=org,
+            workflow=workflow,
+            submission=submission,
+            user_id=user.id,
+            extra={"runtime_profile": ValidationRuntimeProfile.ATTEMPT_STRICT_V1},
+        )
 
 
 @pytest.mark.django_db

--- a/validibot/workflows/tests/test_energyplus_template_integration.py
+++ b/validibot/workflows/tests/test_energyplus_template_integration.py
@@ -49,6 +49,7 @@ from django.test import TestCase
 from validibot.submissions.constants import SubmissionFileType
 from validibot.validations.constants import ENERGYPLUS_MODEL_TEMPLATE
 from validibot.validations.constants import ValidationType
+from validibot.validations.tests.factories import ExecutionAttemptFactory
 from validibot.validations.tests.factories import ValidationStepRunFactory
 from validibot.validations.tests.factories import ValidatorFactory
 from validibot.validations.tests.factories import ValidatorResourceFileFactory
@@ -2282,7 +2283,7 @@ def _make_launcher_fixtures(
         content=submission_content,
     )
 
-    # 6. ValidationRun + StepRun (PENDING)
+    # 6. ValidationRun + StepRun + durable attempt (all PENDING)
     step_run = ValidationStepRunFactory(
         validation_run__workflow=workflow,
         validation_run__org=workflow.org,
@@ -2290,6 +2291,7 @@ def _make_launcher_fixtures(
         workflow_step=step,
     )
     run = step_run.validation_run
+    attempt = ExecutionAttemptFactory(step_run=step_run)
 
     return {
         "run": run,
@@ -2297,6 +2299,7 @@ def _make_launcher_fixtures(
         "submission": submission,
         "step": step,
         "step_run": step_run,
+        "attempt": attempt,
     }
 
 


### PR DESCRIPTION
## Summary

Makes the durable execution-attempt lifecycle Validibot's only active advanced-validator execution architecture.

- removes the operator-facing `VALIDATION_RUNTIME_PROFILE` setting and the active `LEGACY` runtime profile;
- makes the application select `ATTEMPT_LIFECYCLE_V1` for every new run;
- explicitly rejects caller attempts to override the runtime profile;
- removes fallback dispatch, callback, cancellation, and reconciliation behavior based on mutable step-output JSON;
- requires every accepted callback and callback receipt to identify its concrete `ExecutionAttempt`;
- retains the immutable profile field as an internal semantic-version boundary for future strict-I/O and canonical-context releases.

## Why

The previous implementation deliberately supported a mixed-version rollout: `LEGACY` remained the default while operators could opt into the new lifecycle. That is appropriate for a mature system with users and in-flight production work, but Validibot has neither today.

Keeping both paths would therefore preserve branches, nullable relationships, configuration, tests, and operational choices without protecting a real compatibility commitment. It would also allow the unused path to diverge from the architecture we have already selected.

This PR makes the clean cut before production adoption. Runtime profiles remain useful, but only as application-owned versions for future rolling upgrades—not as a choice between execution engines.

## Execution behavior

### Dispatch

- advanced validation creates or reuses one active attempt before provider work;
- Cloud Run and Docker launchers require that attempt and never manufacture a step-based fallback callback ID;
- an already claimed or acceptance-ambiguous attempt cannot be relaunched by task redelivery;
- synchronous Docker now records the complete `PENDING -> DISPATCHING -> RUNNING -> COMPLETED` sequence rather than skipping the `RUNNING` state.

### Callbacks

- callbacks without a valid `execution-attempt-<uuid>` identity are rejected before storage access;
- the attempt must belong to the claimed run and current logical step;
- callback receipts require an attempt foreign key;
- existing terminal receipts are checked before late-attempt handling, preserving cached idempotent responses after a crash or redelivery;
- terminal runs and attempts remain fenced against late output.

### Cancellation and reconciliation

- provider identity comes only from durable attempt columns;
- cancellation and timeout fence the attempt before best-effort provider cancellation;
- GCP reconciliation requires explicit provider status and attempt bundle identity;
- missing/ambiguous provider observations do not fall back to human-readable errors or step-output JSON.

## Migration

Migration `0066_standardize_attempt_lifecycle`:

1. deletes callback receipts whose attempt reference is null;
2. makes `CallbackReceipt.execution_attempt` non-null;
3. changes the model default and current choices to the attempt-based profile ladder.

Unbound receipts are short-lived callback-idempotency bookkeeping, not validation results or evidence. Historical migrations remain unchanged. Any historical `LEGACY` run value remains stored as history but is no longer a supported active execution path.

This intentionally breaking cutover is appropriate because Validibot has no production users or in-flight compatibility obligation.

## Operator impact

- remove `VALIDATION_RUNTIME_PROFILE` from any local or deployment configuration;
- no replacement setting is required;
- self-hosted Celery/Redis/Docker and GCP Cloud Tasks/Cloud Run deployments now use the same attempt invariants automatically.

## Documentation

The public architecture, execution overview, self-hosting configuration, and environment reference now describe the single execution path. A companion private ADR amendment records why the rollout machinery was retired before production adoption.

## Verification

- full test suite: **4,509 passed**, 28 expected skips, 68 subtests passed;
- focused lifecycle/callback/reconciliation/backend tests: passed;
- Django migration consistency check: no changes detected;
- Ruff: passed;
- complete pre-commit suite, including django-upgrade and djLint: passed;
- developer documentation build: passed with no issues;
- `git diff --check`: passed;
- `validibot-shared` resolves to `0.12.0`, matching the latest local release tag `v0.12.0`.

## Review focus

Please confirm:

1. no active execution path can launch or reconcile provider work without an attempt;
2. deletion of unbound rollout-era receipts is acceptable before the non-null constraint;
3. retaining `runtime_profile` internally, while removing operator/caller selection, is the right future upgrade boundary;
4. synchronous Docker's two terminal transitions accurately preserve the lifecycle graph;
5. the intentional lack of compatibility with active `LEGACY` work matches the project's pre-user state.
