### PR TITLE
Use shared JCS for workflow contract hashes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,7 +112,10 @@ dependencies = [
   # engine-status taxonomy + SVRL summary, and the canonical SVRL parser
   # (``validibot_shared.schematron.svrl``) lives here so Django and the
   # container backend parse SVRL identically.
-  "validibot-shared==0.12.0",
+  # 0.12.1 adds the shared RFC 8785 / JCS canonicalization helper used by
+  # workflow-definition contract hashes, keeping community evidence and Pro
+  # credentials on the same portable byte contract.
+  "validibot-shared==0.12.1",
   "django-csp==4.0",
   "django-permissions-policy==4.32.0",
   # OIDC provider runtime deps. allauth.idp.oidc is unconditionally in

--- a/validibot/workflows/services/contract_snapshot.py
+++ b/validibot/workflows/services/contract_snapshot.py
@@ -12,8 +12,8 @@ distinct" caution):
   minimal projection of validation *semantics* (identity, constants, signal
   mapping definitions, and per-step validator + effective-ruleset + assertions).
   This is the only input to the hash.
-* :func:`compute_workflow_definition_hash` — ``sha256`` over the canonical JSON
-  of that preimage.
+* :func:`compute_workflow_definition_hash` — ``sha256`` over RFC 8785 / JCS
+  canonical JSON for that preimage.
 * :func:`build_workflow_contract_snapshot` — the broader **evidence object**: a
   ``validibot_shared.evidence.WorkflowContractSnapshot`` carrying the launch
   contract PLUS the constants, signal-mapping definitions, and the definition
@@ -37,21 +37,19 @@ Design rules encoded here (each is an ADR decision):
 * **Constants store exact values.** A ``NUMBER`` constant's decimal string
   (``"0.40"``) is hashed verbatim, preserving attested precision.
 
-Canonicalization: this module hashes with sorted-key JSON (the same scheme the
-manifest *envelope* already uses), so the community manifest and the Pro
-credential share one byte-for-byte identical hash by both calling
-:func:`compute_workflow_definition_hash`. Moving the canonicalizer to RFC 8785 /
-JCS in ``validibot-shared`` (for third-party verifier portability) is a possible
-future enhancement; it would change the hash *bytes* but not the "single
-projection, no drift" guarantee, since both consumers would swap together.
+Canonicalization: this module hashes with the shared RFC 8785 / JCS helper in
+``validibot-shared``. Pro re-exports that helper for compatibility, but the
+community projection owns the workflow-definition hash so the evidence manifest
+and signed credential cannot drift.
 """
 
 from __future__ import annotations
 
-import hashlib
-import json
 from typing import TYPE_CHECKING
 from typing import Any
+
+from validibot_shared.canonicalization import canonicalize_dict
+from validibot_shared.canonicalization import sha256_hex_for_dict
 
 if TYPE_CHECKING:
     from validibot_shared.evidence import WorkflowContractSnapshot
@@ -78,13 +76,13 @@ def build_workflow_definition_contract(workflow: Workflow) -> dict[str, Any]:
 
 
 def compute_workflow_definition_hash(workflow: Workflow) -> str:
-    """Return ``sha256:<hex>`` over the canonical JSON of the definition contract."""
+    """Return ``sha256:<hex>`` over the JCS bytes of the definition contract."""
     return _hash_preimage(build_workflow_definition_contract(workflow))
 
 
 def _hash_preimage(preimage: dict[str, Any]) -> str:
-    """Return ``sha256:<hex>`` of a preimage's canonical JSON bytes."""
-    return f"sha256:{hashlib.sha256(_canonical_bytes(preimage)).hexdigest()}"
+    """Return ``sha256:<hex>`` of a preimage's RFC 8785 / JCS bytes."""
+    return f"sha256:{sha256_hex_for_dict(preimage)}"
 
 
 def build_workflow_contract_snapshot(workflow: Workflow) -> WorkflowContractSnapshot:
@@ -127,19 +125,8 @@ def build_workflow_contract_snapshot(workflow: Workflow) -> WorkflowContractSnap
 
 
 def _canonical_bytes(data: dict[str, Any]) -> bytes:
-    """Serialize to canonical JSON bytes (sorted keys, compact separators).
-
-    Hash stability comes from this canonical form, NOT from the in-code field
-    ordering above (which is for readability). ``default=str`` defends against a
-    stray non-JSON scalar (e.g. a ``Decimal``) rather than raising.
-    """
-    return json.dumps(
-        data,
-        sort_keys=True,
-        separators=(",", ":"),
-        ensure_ascii=False,
-        default=str,
-    ).encode("utf-8")
+    """Serialize to shared RFC 8785 / JCS bytes for deterministic sorting."""
+    return canonicalize_dict(data)
 
 
 # ── Projections ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Updates the community workflow-definition contract hash to use the shared RFC 8785 / JCS canonicalization helper from `validibot-shared==0.12.1`.

This keeps the community evidence manifest and Pro credential digest on one portable canonical byte contract while preserving the single community projection introduced for constants.

## Changes

- Import `canonicalize_dict()` and `sha256_hex_for_dict()` from `validibot_shared.canonicalization`.
- Hash `build_workflow_definition_contract()` preimages with shared JCS instead of local `json.dumps(sort_keys=True)` serialization.
- Update the contract snapshot module docs to state that shared JCS is the canonical byte contract.
- Bump the `validibot-shared` package requirement to `0.12.1`.

## Why

Constants only work as an attested workflow primitive if every evidence surface hashes the same semantic contract. The community repo owns that contract projection, and shared now owns the canonicalization implementation so third-party verifiers do not need Pro code to reproduce the digest.

## Dependency

Depends on `validibot-shared==0.12.1` from https://github.com/danielmcquillen/validibot-shared/pull/21.

The `uv.lock` refresh is intentionally deferred until `validibot-shared==0.12.1` is published, because the registry release does not exist yet.

## Validation

- `PYTHONPATH=../validibot-shared uv run --no-sync pytest validibot/workflows/tests/test_contract_snapshot.py validibot/workflows/tests/test_constants.py validibot/workflows/tests/test_constant_views.py validibot/validations/tests/services/test_evidence.py`
- `PYTHONPATH=../validibot-shared uv run --no-sync ruff check validibot/workflows/services/contract_snapshot.py validibot/workflows/tests/test_contract_snapshot.py`
- `git diff --check`