### PR TITLE
Harden validator reset and image documentation

### DIFF
--- a/docs/dev_docs/how-to/reset-an-environment.md
+++ b/docs/dev_docs/how-to/reset-an-environment.md
@@ -16,15 +16,24 @@ run it against anything you care about.
 then rebuilds the validator catalogue from the current code:
 
 - **Deletes** every validation run, submission (including the uploaded files in
-  storage), workflow, project, and validator.
+  storage), workflow, project, managed validator execution deployment, and
+  validator.
 - **Rebuilds** the system validators from their config declarations, at
-  version 1, and re-seeds their resource files (weather data and the like).
+  the versions those declarations currently specify, and re-seeds their
+  resource files (weather data and the like).
 - **Preserves** your users and organizations. Nothing about identity or
   membership is touched.
 
 So after a reset you still log in as the same people in the same orgs, but
-every workflow, project, run, and uploaded file is gone, and the validator
-catalogue looks like a fresh install.
+every workflow, project, run, managed provider route, and uploaded file is gone,
+and the validator catalogue looks like a fresh install.
+
+The deletion order is deliberate. Managed execution deployments protect their
+validator rows so that historical routing provenance cannot disappear
+accidentally during ordinary operation. A factory reset therefore deletes those
+deployment records explicitly before replacing the validator catalogue. This
+prevents stale provider resource names, image digests, and release identities
+from surviving into the fresh catalogue.
 
 ## How it keeps you safe
 
@@ -105,6 +114,7 @@ Validibot system reset
     - 388 submissions
     - 57 workflows
     - 120 projects
+    - 12 validator deployments
     - 34 validators
   Will REBUILD: system validators (from current configs) + resource files
   Will PRESERVE: users, organizations
@@ -127,6 +137,7 @@ breakdown and a success line:
   Deleted 388 submission row(s).
   Deleted 57 workflow row(s).
   Deleted 120 project row(s).
+  Deleted 12 validator deployment row(s).
   Deleted 34 validator row(s).
   Recreated 7 baseline validator(s).
   Purged 800 storage object(s).
@@ -152,10 +163,10 @@ force a preview even when the phrase is present.
 
 ## A note on validator versions
 
-After a reset, every system validator is rebuilt at **version 1**. The
-catalogue's config declarations are the source of truth for that, so the reset,
-`setup_validibot`, and `sync_validators` all agree on version 1 — there is no
-risk of a later sync re-introducing higher-numbered rows. If you are bringing an
-older database in line, run `reset_system` rather than a bare `sync_validators`:
-the reset wipes the validators first, whereas syncing without wiping would add
-version 1 rows alongside any older ones still in the table.
+After a reset, every system validator is rebuilt at the version declared by its
+current `ValidatorConfig`. Those declarations are the source of truth, so
+`reset_system`, `setup_validibot`, and `sync_validators` produce the same
+catalogue for the deployed code. If you are bringing an older database in line,
+run `reset_system` rather than a bare `sync_validators`: the reset removes the
+old validators and their managed deployment routes first, whereas syncing
+without wiping intentionally preserves historical catalogue rows.

--- a/docs/dev_docs/overview/execution_backends.md
+++ b/docs/dev_docs/overview/execution_backends.md
@@ -305,7 +305,12 @@ COMPOSE_PROJECT_NAME=validibot docker compose -f docker-compose.production.yml u
 
 ### Private Registry Authentication
 
-By default, validator images are pulled from Docker Hub. If you're using a private registry (GitHub Container Registry, AWS ECR, Google Artifact Registry, etc.), you need to configure Docker credentials on the host.
+Published validator releases are public packages in GitHub Container
+Registry (GHCR), under
+`ghcr.io/mcquilleninteractive/validibot-validator-backend-<slug>:v<release>`.
+Public pulls do not require a registry login. Configure Docker credentials on
+the host only when using a private or internally mirrored registry (for
+example, private GHCR, AWS ECR, or Google Artifact Registry).
 
 **Option 1: Docker login on the host**
 

--- a/docs/dev_docs/validator_jobs_cloud_run.md
+++ b/docs/dev_docs/validator_jobs_cloud_run.md
@@ -542,7 +542,7 @@ Enable advanced validators by listing container images in settings:
 
 ```bash
 # Environment variable
-ADVANCED_VALIDATOR_IMAGES=ghcr.io/validibot/energyplus:24.2.0,ghcr.io/validibot/fmu:0.9.0
+ADVANCED_VALIDATOR_IMAGES=ghcr.io/mcquilleninteractive/validibot-validator-backend-energyplus:v0.15.4,ghcr.io/mcquilleninteractive/validibot-validator-backend-fmu:v0.15.3
 ```
 
 Then sync validators from container metadata:
@@ -555,7 +555,7 @@ python manage.py sync_validators
 python manage.py sync_validators --dry-run
 
 # Sync specific image (ignores ADVANCED_VALIDATOR_IMAGES)
-python manage.py sync_validators --image ghcr.io/validibot/energyplus:24.2.0
+python manage.py sync_validators --image ghcr.io/mcquilleninteractive/validibot-validator-backend-energyplus:v0.15.4
 
 # Skip pulling images (if already present locally)
 python manage.py sync_validators --no-pull

--- a/docs/operations/self-hosting/backups.md
+++ b/docs/operations/self-hosting/backups.md
@@ -13,7 +13,7 @@ A manifested backup contains:
 
 What's NOT in a manifested backup:
 
-- Container images themselves — pull them from GHCR / Docker Hub on restore.
+- Container images themselves — pull released images from the canonical public GHCR packages, or rebuild them from source, on restore.
 - The host OS or Docker daemon — that's an infrastructure-level concern.
 - DNS records or TLS certificates — managed by Caddy, your reverse proxy, or your DNS provider.
 - Application logs older than the rotation window — those go to log rotation, not backup.

--- a/docs/operations/self-hosting/configuration.md
+++ b/docs/operations/self-hosting/configuration.md
@@ -124,7 +124,7 @@ Off by default for self-hosted.
 | Setting | Purpose |
 |---|---|
 | `VALIDIBOT_IMAGE_TAG` | Validibot image tag. `latest` for evaluation, exact version (e.g. `0.8.0`) for production. |
-| `VALIDIBOT_IMAGE_REGISTRY` | Image registry. Default: `ghcr.io/validibot`. Mirror: `validibot` on Docker Hub. |
+| `VALIDIBOT_IMAGE_REGISTRY` | Image registry namespace used by deployment tooling. Published Validibot packages use `ghcr.io/mcquilleninteractive`; no Docker Hub mirror is maintained. |
 | `VALIDIBOT_COMMERCIAL_PACKAGE` | For Pro: `validibot-pro==<version>`. Empty for community. |
 | `VALIDIBOT_PRIVATE_INDEX_URL` | For Pro: `https://<email>:<token>@pypi.validibot.com/simple/`. Empty for community. |
 | `VALIDATOR_CONTAINER_SOCKET` | Host path to the Docker-compatible API socket mounted into the worker. Defaults to `/var/run/docker.sock`; use `/run/user/<numeric-uid>/docker.sock` for rootless Docker. |

--- a/docs/operations/self-hosting/overview.md
+++ b/docs/operations/self-hosting/overview.md
@@ -68,7 +68,8 @@ Self-hosted Validibot is **telemetry-off by default**. No product
 analytics. No license phone-home. No usage reporting. The default
 install makes only these outbound calls:
 
-- container image pulls during install/upgrade (Docker Hub / GHCR);
+- container image pulls during install/upgrade (the canonical public GHCR
+  packages, or an operator-configured private registry);
 - email delivery if you configure an email provider;
 - Let's Encrypt ACME challenges if you enable the bundled Caddy proxy;
 - nothing else.

--- a/docs/operations/self-hosting/upgrades.md
+++ b/docs/operations/self-hosting/upgrades.md
@@ -252,7 +252,11 @@ The Phase 4 MVP doesn't yet implement:
 
 - **`--drain` flag** — wait for in-flight runs to finish before proceeding. Recommended pattern for deployments running long validators; until it lands, schedule upgrades manually during quiet windows.
 - **`--components`-aware rollback** — restore is whole-system today. Component-selective restore is reserved in `validibot.backup.v1` (the manifest schema has the slot) but not yet wired through the recipe.
-- **Pre-built image pulls** — the recipe checks out the version tag and builds locally. A future enhancement could pull a pre-built image from GHCR / Docker Hub when the network can reach them, falling back to local build otherwise.
+- **Pre-built image pulls in the self-hosted recipe** — canonical validator
+  packages are public in GHCR, but the recipe still checks out the version tag
+  and builds locally. A future enhancement could pull the canonical GHCR
+  digest when the network can reach it, falling back to a verified local build
+  otherwise.
 
 These are documented follow-ups, not gaps in design.
 

--- a/docs/operations/self-hosting/validator-images.md
+++ b/docs/operations/self-hosting/validator-images.md
@@ -104,7 +104,7 @@ Policy values:
 
 | Policy | What it does |
 |---|---|
-| `tag` | Default for community quick-start. Image references like `ghcr.io/validibot/energyplus:24.2.0`. |
+| `tag` | Default for community quick-start. Image references like `ghcr.io/mcquilleninteractive/validibot-validator-backend-energyplus:v0.15.4`. |
 | `digest` | Production-recommended. Image references include `@sha256:...` digests pinned at deploy time. |
 | `signed-digest` | High-trust deployments. Requires digest pinning plus enabled/configured cosign verification. |
 
@@ -224,22 +224,30 @@ A reasonable cron entry:
 
 Weekly cleanup at 3am Sunday. The log shows what was removed; if nothing matched, the recipe prints "Nothing to clean up." and exits 0.
 
-## Image registry (planned, not yet active)
+## Public validator images
 
-Today, validator images are built locally on each operator's host from
-the [`validibot-validator-backends`](https://github.com/mcquilleninteractive/validibot-validator-backends)
-checkout (see [What's pre-installed](#whats-pre-installed) above).
-There is no public registry to pull from yet.
+Released validator images are published as public GHCR packages under the
+McQuillen Interactive organization:
 
-When pre-built validator images do ship, the registry plan is:
+```text
+ghcr.io/mcquilleninteractive/validibot-validator-backend-<slug>:v<release>
+```
 
-| Registry | Path | Use |
-|---|---|---|
-| GHCR | `ghcr.io/validibot/<image>` | Canonical source. No pull rate limits. |
-| Docker Hub | `validibot/<image>` | Discoverability mirror. Rate-limited (100 anonymous pulls per 6h per IP). |
+For example:
 
-This table is documented here so operators know the eventual shape;
-nothing breaks today by ignoring it.
+```text
+ghcr.io/mcquilleninteractive/validibot-validator-backend-energyplus:v0.15.4
+```
+
+Public pulls do not require a GHCR login. Validibot does not maintain a Docker
+Hub mirror, and `ghcr.io/validibot/...` is not a Validibot-owned namespace.
+Operators can still build the images locally from the
+[`validibot-validator-backends`](https://github.com/mcquilleninteractive/validibot-validator-backends)
+checkout when auditing or customizing a backend.
+
+Use an exact release tag for evaluation. For production, resolve that tag and
+register the corresponding `@sha256:...` digest before enabling the `digest`
+image policy.
 
 ## See also
 

--- a/validibot/core/management/commands/reset_system.py
+++ b/validibot/core/management/commands/reset_system.py
@@ -2,8 +2,9 @@
 
 This command is the "factory reset" for a deployed environment. It wipes the
 operational data an instance accumulates — validation runs, submissions,
-workflows, and projects — and rebuilds the system validator catalogue from the
-current code, then re-seeds validator resource files.
+workflows, projects, and managed validator deployments — and rebuilds the
+system validator catalogue from the current code, then re-seeds validator
+resource files.
 
 What it deletes
 ---------------
@@ -16,7 +17,10 @@ What it deletes
 2. **Submissions** (and their uploaded files / ``PurgeRetry`` rows).
 3. **Workflows** (cascading their steps and step resources).
 4. **Projects** (cascading anything project-owned that survived the above).
-5. **Validators** (cascading ``CustomValidator``, ``StepIODefinition``,
+5. **Validator execution deployments**, which use ``on_delete=PROTECT`` for
+   their validator reference and therefore must be removed explicitly before
+   the validator catalogue.
+6. **Validators** (cascading ``CustomValidator``, ``StepIODefinition``,
    ``Derivation``, and ``ValidatorResourceFile``), then recreated from the
    current ``ValidatorConfig`` declarations at the versions those configs
    declare — the genuine "latest specifications".
@@ -33,8 +37,10 @@ The order above is forced by the foreign-key ``PROTECT`` graph, not chosen for
 convenience. ``ValidationRun.workflow`` and ``Submission.workflow`` are
 ``PROTECT``, so runs and submissions must die before workflows.
 ``WorkflowStep.validator`` is ``PROTECT``, so workflows (and their cascaded
-steps) must die before validators. Running these deletes in any other order
-raises ``ProtectedError`` and aborts the whole transaction.
+steps) must die before validators. ``ValidatorExecutionDeployment.validator``
+is also ``PROTECT``, so deployment records must die before validators. Running
+these deletes in any other order raises ``ProtectedError`` and aborts the whole
+transaction.
 
 Why a confirmation argument and not just a prompt
 -------------------------------------------------
@@ -90,6 +96,7 @@ from validibot.projects.models import Project
 from validibot.submissions.models import Submission
 from validibot.validations.models import ValidationRun
 from validibot.validations.models import Validator
+from validibot.validations.models import ValidatorExecutionDeployment
 from validibot.validations.utils import create_default_validators
 from validibot.workflows.models import Workflow
 
@@ -104,8 +111,9 @@ CONFIRM_PHRASE = "RESET-EVERYTHING"
 
 class Command(BaseCommand):
     help = (
-        "DESTRUCTIVE: delete all runs, submissions, workflows, projects and "
-        "validators, then rebuild the validator catalogue. Dry-run by default; "
+        "DESTRUCTIVE: delete all runs, submissions, workflows, projects, "
+        "validator deployments and validators, then rebuild the validator "
+        "catalogue. Dry-run by default; "
         f'requires --confirm "{CONFIRM_PHRASE}" to actually delete.'
     )
 
@@ -211,6 +219,7 @@ class Command(BaseCommand):
             "submissions": Submission.objects.count(),
             "workflows": Workflow.objects.count(),
             "projects": Project.objects.count(),
+            "validator deployments": ValidatorExecutionDeployment.objects.count(),
             "validators": Validator.objects.count(),
         }
 
@@ -344,9 +353,18 @@ class Command(BaseCommand):
         proj_deleted, _ = Project.objects.all().delete()
         self.stdout.write(f"  Deleted {proj_deleted} project row(s).")
 
-        # Validators last: now that no step references them, they (and their
-        # CustomValidator / StepIODefinition / Derivation / ValidatorResourceFile
-        # children) delete cleanly.
+        # Deployment records also PROTECT their validators. They describe
+        # provider routes for the old catalogue, so a factory reset removes
+        # them rather than carrying stale image and provider identities into
+        # the rebuilt catalogue.
+        deployment_deleted, _ = ValidatorExecutionDeployment.objects.all().delete()
+        self.stdout.write(
+            f"  Deleted {deployment_deleted} validator deployment row(s).",
+        )
+
+        # Validators last: now that neither steps nor execution deployments
+        # reference them, they (and their CustomValidator / StepIODefinition /
+        # Derivation / ValidatorResourceFile children) delete cleanly.
         val_deleted, _ = Validator.objects.all().delete()
         self.stdout.write(f"  Deleted {val_deleted} validator row(s).")
 

--- a/validibot/core/tests/test_reset_system.py
+++ b/validibot/core/tests/test_reset_system.py
@@ -1,9 +1,9 @@
 """Tests for the ``reset_system`` management command.
 
 ``reset_system`` is the deployment "factory reset": it permanently deletes all
-operational data — validation runs, submissions, workflows, projects, and
-validators — and then rebuilds the system validator catalogue, while preserving
-users and organizations.
+operational data — validation runs, submissions, workflows, projects, managed
+validator deployments, and validators — and then rebuilds the system validator
+catalogue, while preserving users and organizations.
 
 This suite exists because the command is irreversibly destructive and is meant
 to be run against production environments. Three classes of regression would be
@@ -15,10 +15,10 @@ catastrophic, so each is pinned here:
   3. A ``ProtectedError`` from getting the FK ``PROTECT`` deletion order wrong,
      which would abort the whole reset partway through.
 
-The fixtures deliberately build a dataset that exercises both community
-``PROTECT`` edges: ``ValidationRun.workflow`` and ``WorkflowStep.validator``. If
-the command deleted in the wrong order, those edges would raise and the wipe
-tests would fail loudly.
+The fixtures deliberately build a dataset that exercises all relevant community
+``PROTECT`` edges: ``ValidationRun.workflow``, ``WorkflowStep.validator``, and
+``ValidatorExecutionDeployment.validator``. If the command deleted in the wrong
+order, those edges would raise and the wipe tests would fail loudly.
 """
 
 from io import StringIO
@@ -32,8 +32,11 @@ from validibot.projects.models import Project
 from validibot.submissions.models import Submission
 from validibot.users.models import Organization
 from validibot.users.models import User
+from validibot.validations.constants import ExecutionDeploymentKind
+from validibot.validations.constants import ExecutionProviderType
 from validibot.validations.models import ValidationRun
 from validibot.validations.models import Validator
+from validibot.validations.models import ValidatorExecutionDeployment
 from validibot.validations.tests.factories import ValidationRunFactory
 from validibot.validations.validators.base.config import get_all_configs
 from validibot.workflows.models import Workflow
@@ -48,12 +51,66 @@ def populated(db):
     A single ``ValidationRunFactory`` transitively creates an organization, a
     user, a project, a workflow, and a submission. We then attach a
     ``WorkflowStep`` (which owns a ``Validator`` via ``PROTECT``) to that same
-    workflow. The result touches every entity the reset deletes *and* both
-    ``PROTECT`` edges the deletion order has to respect, so a single fixture
-    validates the ordering contract.
+    workflow, then register a managed execution deployment which also protects
+    the validator. The result touches every entity the reset deletes and every
+    relevant ``PROTECT`` edge, so a single fixture validates the ordering
+    contract.
     """
     run = ValidationRunFactory()
-    WorkflowStepFactory(workflow=run.workflow)
+    step = WorkflowStepFactory(workflow=run.workflow)
+    image_digest = f"sha256:{'a' * 64}"
+    service_url = "https://validibot-reset-test.example.run.app"
+    runtime_identity = "validator-runtime@reset-test.iam.gserviceaccount.com"
+    ValidatorExecutionDeployment.objects.create(
+        validator=step.validator,
+        provider_type=ExecutionProviderType.GCP,
+        deployment_kind=ExecutionDeploymentKind.CLOUD_RUN_SERVICE,
+        display_name="Reset regression deployment",
+        deployment_revision="reset-test-r1",
+        provider_configuration={
+            "project_id": "reset-test",
+            "region": "australia-southeast1",
+            "service_name": "validibot-reset-test",
+            "service_url": service_url,
+            "authentication_audience": service_url,
+            "runtime_service_account": runtime_identity,
+            "invoker_service_account": (
+                "validator-invoker@reset-test.iam.gserviceaccount.com"
+            ),
+        },
+        provider_resource_name=(
+            "projects/reset-test/locations/australia-southeast1/"
+            "services/validibot-reset-test"
+        ),
+        route=service_url,
+        authentication_audience=service_url,
+        backend_release_identity="0.1.0",
+        backend_image_ref=(
+            "ghcr.io/mcquilleninteractive/"
+            f"validibot-validator-backend-energyplus@{image_digest}"
+        ),
+        backend_image_digest=image_digest,
+        expected_runtime_identity=runtime_identity,
+        declared_capabilities={
+            "runtime_contract_version": "validibot-execution-v1",
+            "maximum_execution_seconds": 300,
+            "execution_shape": "REQUEST",
+            "status_lookup": "UNSUPPORTED",
+            "cancellation": "BEST_EFFORT",
+            "storage_capability": "gcs_downscoped_token",
+            "storage_isolation": "attempt_scoped",
+            "architectures": ["linux-amd64"],
+            "maximum_cpu_millis": 1000,
+            "maximum_memory_mib": 1024,
+            "callback_authentication": "ATTEMPT_NONCE_AND_OIDC",
+        },
+        maximum_execution_seconds=300,
+        request_timeout_seconds=600,
+        dispatch_timeout_seconds=1800,
+        minimum_instances=0,
+        maximum_instances=1,
+        concurrency=1,
+    )
     return run
 
 
@@ -88,6 +145,7 @@ class TestConfirmationGate:
         assert Submission.objects.count() == 1
         assert Workflow.objects.count() == 1
         assert WorkflowStep.objects.count() == 1
+        assert ValidatorExecutionDeployment.objects.count() == 1
         assert Validator.objects.count() == 1
 
     def test_wrong_phrase_errors_and_deletes_nothing(self, populated):
@@ -121,7 +179,9 @@ class TestConfirmationGate:
         )
 
         assert "DRY RUN" in out.getvalue()
+        assert "- 1 validator deployments" in out.getvalue()
         assert Workflow.objects.count() == 1
+        assert ValidatorExecutionDeployment.objects.count() == 1
         assert Validator.objects.count() == 1
 
 
@@ -142,10 +202,11 @@ class TestFullReset:
         """The happy path: confirm, wipe, preserve users/orgs, rebuild validators.
 
         This is the end-to-end contract. It also implicitly proves the
-        ``PROTECT`` ordering is correct: the fixture wires a run onto a workflow
-        (``PROTECT``) and a step onto a validator (``PROTECT``). If the command
-        deleted workflows before runs, or validators before steps, Django would
-        raise ``ProtectedError`` and this test would fail instead of passing.
+        ``PROTECT`` ordering is correct: the fixture wires a run onto a workflow,
+        a step onto a validator, and a managed deployment onto that validator.
+        If the command deleted workflows before runs, or validators before
+        steps and deployments, Django would raise ``ProtectedError`` and this
+        test would fail instead of passing.
         """
         # Identity rows we expect to survive the wipe.
         orgs_before = Organization.objects.count()
@@ -169,6 +230,7 @@ class TestFullReset:
         assert Workflow.objects.count() == 0
         assert WorkflowStep.objects.count() == 0
         assert Project.objects.count() == 0
+        assert ValidatorExecutionDeployment.objects.count() == 0
 
         # Validators are rebuilt from the current configs (not left empty). The
         # baseline "basic-validator" always ships, so its presence proves the
@@ -187,6 +249,7 @@ class TestFullReset:
         assert Organization.objects.count() == orgs_before
         assert User.objects.count() == users_before
 
+        assert "Deleted 1 validator deployment row(s)." in out.getvalue()
         assert "System reset complete" in out.getvalue()
 
     def test_reset_is_safe_on_an_empty_database(self, db):

--- a/validibot/validations/tests/services/test_gcp_service_dispatch.py
+++ b/validibot/validations/tests/services/test_gcp_service_dispatch.py
@@ -91,7 +91,10 @@ def _attempt(*, state=ExecutionAttemptState.PENDING):
             f"projects/{PROJECT_ID}/locations/{REGION}/services/{SERVICE_NAME}"
         ),
         backend_release_identity="0.15.0",
-        backend_image_ref=f"ghcr.io/validibot/energyplus@{DIGEST}",
+        backend_image_ref=(
+            "ghcr.io/mcquilleninteractive/"
+            f"validibot-validator-backend-energyplus@{DIGEST}"
+        ),
         backend_image_digest=DIGEST,
         expected_runtime_identity=RUNTIME_IDENTITY,
         declared_capabilities=_capabilities(),


### PR DESCRIPTION
## Summary

This PR combines two related validator hardening changes:

- replaces obsolete or unowned `ghcr.io/validibot` examples with the canonical public `ghcr.io/mcquilleninteractive/validibot-validator-backend-*` packages
- removes incorrect Docker Hub mirror and public-image login guidance
- documents immutable digest-pinned production deployments
- includes `ValidatorExecutionDeployment` records in reset previews
- deletes managed validator deployments before deleting the protected validator catalogue
- adds regression coverage and updates the reset documentation

## Why

### 1. Canonical validator images

The old `ghcr.io/validibot/...` namespace is not controlled by this project. Documentation pointing operators there creates an operational failure mode and supply-chain ambiguity.

Validator releases are public GHCR packages under the `mcquilleninteractive` organization. No Docker Hub mirror is maintained.

The updated documentation now:

- consistently uses `ghcr.io/mcquilleninteractive/validibot-validator-backend-<slug>:v<release>`
- states that pulling these public images does not require a GHCR login
- explicitly warns that `ghcr.io/validibot/...` is not a Validibot-owned namespace
- recommends resolving release tags to immutable `@sha256:...` digests for production registration and deployment

### 2. Reliable clean reset

`ValidatorExecutionDeployment.validator` uses `on_delete=PROTECT`.

The reset command previously attempted to delete validators without first deleting their managed deployment records. On a configured environment, this could raise `ProtectedError`, roll back the transaction, and leave stale deployment information in place, including:

- provider resource names
- container image references
- resolved image digests
- routes and audiences
- release identities and capabilities

The reset order is now:

1. validation runs
2. submissions
3. workflows
4. projects
5. validator execution deployments
6. validators
7. rebuild the validator catalogue from the current declarations

## Behavioral details

- dry-run output now counts managed validator deployments
- confirmed resets delete deployment records before validators, satisfying the foreign-key protection graph
- users and organizations remain preserved
- validators are rebuilt using the versions declared by the current configuration
- the existing confirmation phrase and dry-run default remain unchanged
- no database migration is required

## Security and operational impact

- operator documentation now identifies the controlled public GHCR source
- the unowned `ghcr.io/validibot/...` namespace is explicitly called out
- production examples direct operators toward immutable digest pinning
- deliberate factory resets remove stale deployment identities atomically before rebuilding the validator catalogue
- regression coverage uses a valid, digest-pinned managed Cloud Run deployment so the `PROTECT` deletion ordering is exercised directly

## Verification

- pre-commit hooks, including private-key detection and TruffleHog: passed
- Ruff checks and formatting: passed
- focused test suite: **15 passed**
  - `validibot/core/tests/test_reset_system.py`
  - `validibot/validations/tests/services/test_gcp_service_dispatch.py`
- documentation build: passed with no issues
- mypy baseline: passed
- `git diff --check`: passed
- `validibot-shared` dependency and lockfile verified at `0.22.0`

## Reviewer guide

The two highest-value review points are:

1. Confirm that the canonical GHCR package naming and digest guidance match the `validibot-validator-backends` release pipeline.
2. Confirm that managed validator deployments are intentionally treated as disposable environment state and deleted before validators, while users and organizations remain preserved.