### PR TITLE
Fix validator release command version arguments

### DIFF
--- a/just/gcp/mod.just
+++ b/just/gcp/mod.just
@@ -4363,7 +4363,7 @@ validator-backend-route name stage version mode="normal" cause="SUPERSEDED_BY_AC
         REASON_ARG="--reason-b64={{reason_b64}}"
     fi
     just gcp management-cmd {{stage}} \
-        "activate_validator_backend_release --backend={{name}} --version={{version}} --mode={{mode}} --cause={{cause}} $ALLOW_ARG $REASON_ARG"
+        "activate_validator_backend_release --backend={{name}} --release-version={{version}} --mode={{mode}} --cause={{cause}} $ALLOW_ARG $REASON_ARG"
 
 # Change mutable service-level warming/capacity, then verify and audit the live
 # settings without creating a new Cloud Run revision.
@@ -4912,7 +4912,7 @@ validator-cleanup stage: _require-gcp-config
                 "record_validator_provider_deletion --resource=$resource"
         done
         just gcp management-cmd {{stage}} \
-            "retire_validator_backend_release --backend=$backend --version=$version --reason='Provider pair deleted after verified seven-day drain.'"
+            "retire_validator_backend_release --backend=$backend --release-version=$version --reason='Provider pair deleted after verified seven-day drain.'"
     done
 
 # Report persisted p50/p95 timing stages without blending Job and Service

--- a/tests/test_validator_release_operator_contract.py
+++ b/tests/test_validator_release_operator_contract.py
@@ -203,6 +203,33 @@ def test_exact_recovery_requires_and_transports_a_recorded_repair_reason():
     assert "--reason-b64={{reason_b64}}" in route
 
 
+def test_release_lifecycle_recipes_avoid_django_reserved_version_option():
+    """Operator recipes must not shadow Django's global ``--version`` flag."""
+
+    text = PUBLIC_GCP_RECIPES.read_text(encoding="utf-8")
+    route = _recipe(
+        text,
+        (
+            "validator-backend-route name stage version "
+            'mode="normal" cause="SUPERSEDED_BY_ACCEPTED_RELEASE" '
+            'allow_unaccepted="" reason_b64=""'
+        ),
+        "# Change mutable service-level warming",
+    )
+    cleanup = _recipe(
+        text,
+        "validator-cleanup stage",
+        "# Report persisted p50/p95 timing stages",
+    )
+
+    assert "activate_validator_backend_release" in route
+    assert "--release-version={{version}}" in route
+    assert "--version={{version}}" not in route
+    assert "retire_validator_backend_release" in cleanup
+    assert "--release-version=$version" in cleanup
+    assert "--version=$version" not in cleanup
+
+
 def test_release_preflight_names_each_missing_publication_artifact():
     """Operators must see the exact absent trust artifact before GCP mutation."""
 

--- a/validibot/validations/management/commands/activate_validator_backend_release.py
+++ b/validibot/validations/management/commands/activate_validator_backend_release.py
@@ -27,7 +27,11 @@ class Command(BaseCommand):
     def add_arguments(self, parser):
         """Require exact backend, version, mode, and bounded lifecycle cause."""
         parser.add_argument("--backend", required=True)
-        parser.add_argument("--version", required=True)
+        parser.add_argument(
+            "--release-version",
+            required=True,
+            help="Exact semantic backend release version to activate.",
+        )
         parser.add_argument(
             "--mode",
             choices=[
@@ -75,7 +79,7 @@ class Command(BaseCommand):
         try:
             pairs = activate_backend_release(
                 backend_slug=options["backend"],
-                backend_release_identity=options["version"],
+                backend_release_identity=options["release_version"],
                 mode=options["mode"],
                 deactivation_cause=options["cause"],
                 require_accepted=not options["allow_unaccepted"],
@@ -91,6 +95,6 @@ class Command(BaseCommand):
         self.stdout.write(
             self.style.SUCCESS(
                 f"Activated {len(pairs)} pair(s) for {options['backend']} "
-                f"{options['version']} in {options['mode']} mode."
+                f"{options['release_version']} in {options['mode']} mode."
             )
         )

--- a/validibot/validations/management/commands/retire_validator_backend_release.py
+++ b/validibot/validations/management/commands/retire_validator_backend_release.py
@@ -19,7 +19,11 @@ class Command(BaseCommand):
     def add_arguments(self, parser):
         """Require exact identity and the auditable retirement reason."""
         parser.add_argument("--backend", required=True)
-        parser.add_argument("--version", required=True)
+        parser.add_argument(
+            "--release-version",
+            required=True,
+            help="Exact semantic backend release version to retire.",
+        )
         parser.add_argument("--reason", required=True)
 
     def handle(self, *args, **options):
@@ -27,7 +31,7 @@ class Command(BaseCommand):
         try:
             deployments = retire_backend_release_deployments(
                 backend_slug=options["backend"],
-                backend_release_identity=options["version"],
+                backend_release_identity=options["release_version"],
                 reason=options["reason"],
             )
         except (ExecutionDeploymentResolutionError, ValueError) as exc:

--- a/validibot/validations/tests/test_validator_release_management_commands.py
+++ b/validibot/validations/tests/test_validator_release_management_commands.py
@@ -1,0 +1,51 @@
+"""Regression tests for validator release management-command interfaces.
+
+Django's ``BaseCommand`` reserves global options such as ``--version``.
+Release lifecycle commands must therefore use a distinct option name for the
+backend release identity, or their parsers fail before any operator action can
+run. These tests construct the real parsers so option collisions cannot hide
+behind service-level test coverage.
+"""
+
+from validibot.validations.management.commands import activate_validator_backend_release
+from validibot.validations.management.commands import retire_validator_backend_release
+
+
+def test_activation_parser_accepts_release_version_without_shadowing_django():
+    """Activation must keep Django's flag while parsing release identity."""
+    parser = activate_validator_backend_release.Command().create_parser(
+        "manage.py",
+        "activate_validator_backend_release",
+    )
+
+    options = parser.parse_args(
+        [
+            "--backend",
+            "energyplus",
+            "--release-version",
+            "0.15.4",
+        ]
+    )
+
+    assert options.release_version == "0.15.4"
+
+
+def test_retirement_parser_accepts_release_version_without_shadowing_django():
+    """Retirement must remain callable when its exact backend version is supplied."""
+    parser = retire_validator_backend_release.Command().create_parser(
+        "manage.py",
+        "retire_validator_backend_release",
+    )
+
+    options = parser.parse_args(
+        [
+            "--backend",
+            "energyplus",
+            "--release-version",
+            "0.15.4",
+            "--reason",
+            "Verified drain completed.",
+        ]
+    )
+
+    assert options.release_version == "0.15.4"


### PR DESCRIPTION
## Summary

- rename the validator release lifecycle option from `--version` to `--release-version` in activation and retirement commands
- update the GCP routing and cleanup recipes to use the new option
- add parser-level and operator-recipe regression tests

## Why

Django's `BaseCommand` already reserves the global `--version` option. Defining it again caused parser construction to raise `argparse.ArgumentError` before backend activation could run.

During the production validator setup, resource provisioning and database synchronization completed, but activation failed and the safety trap correctly kept production in maintenance. The retirement command contained the same latent collision and is fixed in this PR as well.

Sentry event: `69657bc903b048e6b4db3e8978d0976b`

## Validation

- full test suite: 4,995 passed, 28 expected environment-gated skips
- focused regression suite: 11 passed
- pre-commit checks on changed files: passed
- mypy baseline: passed
- Django parser/help construction for both commands: passed
- lockfile consistency check: passed
- `validibot-shared` declaration and lockfile remain on current compatible `0.22.0`