### PR TITLE
Separate maintenance mode from database parking

### DIFF
--- a/docs/dev_docs/deployment/deploy-gcp.md
+++ b/docs/dev_docs/deployment/deploy-gcp.md
@@ -208,7 +208,7 @@ happens when `validibot-pro` (or enterprise) is installed. So a
 community-only deployment can build and deploy the image but the
 enabled container will exit during the license check. A
 `deploy-maintenance` revision is instead internal and explicitly disabled, so
-it can become ready while Django is offline. `maintenance-off` exposes Django
+it can become ready while Django is offline. `mode-live` exposes Django
 first and then re-enables MCP, which creates an enabled revision that performs
 the same fail-closed license check before serving traffic.
 

--- a/docs/dev_docs/deployment/justfile-guide.md
+++ b/docs/dev_docs/deployment/justfile-guide.md
@@ -174,22 +174,24 @@ just gcp scheduler-setup dev           # Create scheduled jobs
 just gcp lb-setup prod "example.com"   # Set up HTTPS load balancer
 
 # Maintenance
-just gcp maintenance-on dev            # Isolate runtime/work, start/keep DB ready
-just gcp maintenance-status dev        # Report ONLINE/MAINTENANCE/PARKED/transition
+just gcp mode-maintenance dev          # Isolate runtime/work, start/keep DB ready
+just gcp mode-status dev               # Report LIVE/MAINTENANCE/PARKED/transition
 just gcp deploy-maintenance dev         # Deploy latest but remain offline
 just gcp init-stage-maintenance dev     # Reconcile infra but remain offline
 just gcp maintenance-management-cmd dev "check_validibot --strict"
-just gcp maintenance-park dev           # Explicitly stop DB after maintenance work
-just gcp maintenance-off dev            # Ensure DB ready, then safely resume
+just gcp mode-parked dev               # Take the stage offline and stop DB
+just gcp mode-live dev                 # Ensure DB ready, then safely resume
 ```
 
-`deploy`, `deploy-worker`, and `deploy-all` deliberately refuse to run while
-Cloud SQL is stopped. `maintenance-on` is the fail-closed entry point: it forces
-all services to internal ingress and zero minimums, pauses scheduler/queue work,
-and starts or keeps Cloud SQL RUNNABLE for consecutive operator tasks.
+`deploy`, `deploy-worker`, and `deploy-all` deliberately require a complete
+`LIVE` stage: database ready, normal public runtime ingress, running queues,
+and every managed scheduler job enabled. `mode-maintenance` is the fail-closed
+entry point: it forces all services to internal ingress and zero minimums,
+pauses scheduler/queue work, and starts or keeps Cloud SQL RUNNABLE for
+consecutive operator tasks.
 `deploy-maintenance`, maintenance management commands, and validator operations
 leave the database running; their EXIT traps restore runtime isolation without
-changing database state. Use `maintenance-park` as the sole explicit SQL stop
+changing database state. Use `mode-parked` as the sole explicit SQL stop
 after all maintenance work is complete. Database starts and stops are
 asynchronous and poll both instance state and active provider operations, so
 slow provider maintenance cannot outlive the local CLI wait; the default
@@ -198,7 +200,7 @@ slow provider maintenance cannot outlive the local CLI wait; the default
 individual Cloud Run, scheduler, and queue operations: it skips resources
 already isolated, records failures, and attempts every remaining safeguard
 before returning non-zero. Optional MCP revisions are deployed with
-`VALIDIBOT_MCP_ENABLED=false`; `maintenance-off` makes web reachable first and
+`VALIDIBOT_MCP_ENABLED=false`; `mode-live` makes web reachable first and
 then restores the configured MCP value so its normal startup license check can
 succeed without weakening the gate.
 

--- a/docs/dev_docs/deployment/justfile-guide.md
+++ b/docs/dev_docs/deployment/justfile-guide.md
@@ -174,26 +174,30 @@ just gcp scheduler-setup dev           # Create scheduled jobs
 just gcp lb-setup prod "example.com"   # Set up HTTPS load balancer
 
 # Maintenance
-just gcp maintenance-on dev            # Internal/min=0, pause work, stop DB
-just gcp maintenance-status dev        # Verify all offline-state signals
+just gcp maintenance-on dev            # Isolate runtime/work, start/keep DB ready
+just gcp maintenance-status dev        # Report ONLINE/MAINTENANCE/PARKED/transition
 just gcp deploy-maintenance dev         # Deploy latest but remain offline
 just gcp init-stage-maintenance dev     # Reconcile infra but remain offline
 just gcp maintenance-management-cmd dev "check_validibot --strict"
-just gcp maintenance-off dev           # Start DB first, then safely resume
+just gcp maintenance-park dev           # Explicitly stop DB after maintenance work
+just gcp maintenance-off dev            # Ensure DB ready, then safely resume
 ```
 
 `deploy`, `deploy-worker`, and `deploy-all` deliberately refuse to run while
-Cloud SQL is stopped. `deploy-maintenance` is the fail-closed alternative: it
-briefly starts only the database for migrations, forces all deployed services
-to internal ingress and zero minimums, pauses new scheduler/queue work, and
-restores full maintenance mode on success or failure. Its Cloud SQL transitions
-are asynchronous and poll both instance state and active provider operations,
-so scheduled maintenance cannot outlive the local CLI wait; the default
+Cloud SQL is stopped. `maintenance-on` is the fail-closed entry point: it forces
+all services to internal ingress and zero minimums, pauses scheduler/queue work,
+and starts or keeps Cloud SQL RUNNABLE for consecutive operator tasks.
+`deploy-maintenance`, maintenance management commands, and validator operations
+leave the database running; their EXIT traps restore runtime isolation without
+changing database state. Use `maintenance-park` as the sole explicit SQL stop
+after all maintenance work is complete. Database starts and stops are
+asynchronous and poll both instance state and active provider operations, so
+slow provider maintenance cannot outlive the local CLI wait; the default
 30-minute deadline can be overridden with
-`GCP_SQL_TRANSITION_TIMEOUT_SECONDS`. Cleanup is best-effort across individual
-Cloud Run, scheduler, and queue operations: it skips resources already in the
-desired offline state, records failures, and continues to the database stop
-before returning a non-zero status. Optional MCP revisions are deployed with
+`GCP_SQL_TRANSITION_TIMEOUT_SECONDS`. Runtime cleanup is best-effort across
+individual Cloud Run, scheduler, and queue operations: it skips resources
+already isolated, records failures, and attempts every remaining safeguard
+before returning non-zero. Optional MCP revisions are deployed with
 `VALIDIBOT_MCP_ENABLED=false`; `maintenance-off` makes web reachable first and
 then restores the configured MCP value so its normal startup license check can
 succeed without weakening the gate.

--- a/docs/dev_docs/google_cloud/deployment.md
+++ b/docs/dev_docs/google_cloud/deployment.md
@@ -170,9 +170,10 @@ just gcp deploy-all <stage>
 # e.g., just gcp deploy-all dev|staging|prod
 ```
 
-The standard deploy recipes require Cloud SQL to be running and refuse a stage
-that is in maintenance mode. To stage the latest application while keeping the
-site offline, first use `just gcp maintenance-on <stage>`, then
+The standard deploy recipes require a complete `LIVE` stage: database ready,
+normal public runtime ingress, running queues, and every managed scheduler job
+enabled. To stage the latest application while keeping the site offline, first
+use `just gcp mode-maintenance <stage>`, then
 `just gcp deploy-maintenance <stage>`. Maintenance entry isolates every runtime,
 pauses queues and schedulers, and starts or keeps Cloud SQL RUNNABLE. The deploy
 uses that same database for migrations and deploys web, worker, schedulers, and
@@ -184,14 +185,14 @@ zero minimum capacity. That matters when a newly selected revision is
 unhealthy: a redundant service update could otherwise fail before the remaining
 runtime safeguards are restored.
 
-Use `just gcp maintenance-park <stage>` as the sole explicit database stop after
+Use `just gcp mode-parked <stage>` as the sole explicit database stop after
 all maintenance work is complete. Database start and stop requests are
 submitted asynchronously and poll both instance state and the absence of an
 active control-plane operation, covering slow provider maintenance and eventual
 state reporting. The default transition deadline is 30 minutes; set
 `GCP_SQL_TRANSITION_TIMEOUT_SECONDS` for an exceptional longer operation.
-`maintenance-status` reports `ONLINE`, `MAINTENANCE`, `PARKED`, or
-`PARTIALLY TRANSITIONED` from runtime, queue, scheduler, and database signals.
+`mode-status` reports `LIVE`, `MAINTENANCE`, `PARKED`, or
+`PARTIALLY_TRANSITIONED` from runtime, queue, scheduler, and database signals.
 Optional MCP is internal, zero-capacity, and explicitly disabled while isolated.
 Taking the stage online exposes web first and then restores the configured MCP
 kill-switch value, which runs the normal license check.
@@ -516,20 +517,20 @@ just gcp status-all
 
 ```bash
 # Isolate runtime/work and start or keep the database available
-just gcp maintenance-on dev
+just gcp mode-maintenance dev
 
-# Report ONLINE, MAINTENANCE, PARKED, or PARTIALLY TRANSITIONED
-just gcp maintenance-status dev
+# Report LIVE, MAINTENANCE, PARKED, or PARTIALLY_TRANSITIONED
+just gcp mode-status dev
 
 # Stage a release or run a management command without opening the stage
 just gcp deploy-maintenance dev
 just gcp maintenance-management-cmd dev "check_validibot --strict"
 
 # Explicitly stop the database after all maintenance work
-just gcp maintenance-park dev
+just gcp mode-parked dev
 
 # Or restore capacity, queues, schedulers, and ingress
-just gcp maintenance-off dev
+just gcp mode-live dev
 ```
 
 The lower-level `pause`/`resume` recipes only change web ingress. Use the

--- a/docs/dev_docs/google_cloud/deployment.md
+++ b/docs/dev_docs/google_cloud/deployment.md
@@ -172,28 +172,29 @@ just gcp deploy-all <stage>
 
 The standard deploy recipes require Cloud SQL to be running and refuse a stage
 that is in maintenance mode. To stage the latest application while keeping the
-site offline, use `just gcp deploy-maintenance <stage>`. It confirms the stage
-is already offline, starts only Cloud SQL for migrations, deploys web, worker,
-schedulers, and optional MCP with internal ingress and zero minimum capacity,
-then stops Cloud SQL and re-pauses all work. An exit trap restores maintenance
-mode even if an intermediate step fails. The cleanup first inspects Cloud Run
-and skips services that are already internal with zero minimum capacity. That
-matters when a newly selected revision is unhealthy: a redundant service update
-could otherwise fail before cleanup reaches Cloud SQL. Other service, queue,
-and scheduler failures are collected while every remaining safeguard is still
-attempted; the recipe reports failure only after the database stop path runs.
+site offline, first use `just gcp maintenance-on <stage>`, then
+`just gcp deploy-maintenance <stage>`. Maintenance entry isolates every runtime,
+pauses queues and schedulers, and starts or keeps Cloud SQL RUNNABLE. The deploy
+uses that same database for migrations and deploys web, worker, schedulers, and
+optional MCP with internal ingress and zero minimum capacity. An exit trap
+restores runtime isolation after success or failure without stopping the
+database, so consecutive maintenance operations do not repeatedly restart SQL.
+The cleanup first inspects Cloud Run and skips services already internal with
+zero minimum capacity. That matters when a newly selected revision is
+unhealthy: a redundant service update could otherwise fail before the remaining
+runtime safeguards are restored.
 
-Database start and stop requests are submitted asynchronously and the recipes
-poll both the instance state and the absence of an active control-plane
-operation, which also covers slow provider maintenance and eventual state
-reporting. The default transition deadline is 30 minutes; set
+Use `just gcp maintenance-park <stage>` as the sole explicit database stop after
+all maintenance work is complete. Database start and stop requests are
+submitted asynchronously and poll both instance state and the absence of an
+active control-plane operation, covering slow provider maintenance and eventual
+state reporting. The default transition deadline is 30 minutes; set
 `GCP_SQL_TRANSITION_TIMEOUT_SECONDS` for an exceptional longer operation.
-`maintenance-status` applies the same two-part database check, so a transitional
-`STOPPED` state is not reported as safely offline too early. Optional MCP is
-also internal, zero-capacity, and explicitly disabled while offline. Its
-revision starts without contacting the unavailable Django issuer; taking the
-stage online exposes web first and then restores the configured MCP kill-switch
-value, which runs the normal license check.
+`maintenance-status` reports `ONLINE`, `MAINTENANCE`, `PARKED`, or
+`PARTIALLY TRANSITIONED` from runtime, queue, scheduler, and database signals.
+Optional MCP is internal, zero-capacity, and explicitly disabled while isolated.
+Taking the stage online exposes web first and then restores the configured MCP
+kill-switch value, which runs the normal license check.
 
 ### Step 5: Database and Application Initialization
 
@@ -514,17 +515,20 @@ just gcp status-all
 ### Pause/Resume Service
 
 ```bash
-# Fully stop a stage: internal ingress, min=0, paused work, stopped database
+# Isolate runtime/work and start or keep the database available
 just gcp maintenance-on dev
 
-# Check every offline-state signal
+# Report ONLINE, MAINTENANCE, PARKED, or PARTIALLY TRANSITIONED
 just gcp maintenance-status dev
 
 # Stage a release or run a management command without opening the stage
 just gcp deploy-maintenance dev
 just gcp maintenance-management-cmd dev "check_validibot --strict"
 
-# Restore database first, then capacity, queues, schedulers, and ingress
+# Explicitly stop the database after all maintenance work
+just gcp maintenance-park dev
+
+# Or restore capacity, queues, schedulers, and ingress
 just gcp maintenance-off dev
 ```
 

--- a/docs/dev_docs/mcp/index.md
+++ b/docs/dev_docs/mcp/index.md
@@ -49,7 +49,7 @@ deployments. Two independent gates protect it:
    immediately on this check. GCP maintenance is intentionally different:
    the staged revision is internal and has `VALIDIBOT_MCP_ENABLED=false`, so
    it can become ready while Django is offline but every tool is still closed
-   with 503. `maintenance-off` exposes web first, re-enables MCP, and the new
+   with 503. `mode-live` exposes web first, re-enables MCP, and the new
    online revision then performs the normal license check.
 
 Both gates exist deliberately: the build-time flag keeps the MCP

--- a/docs/help_pages/validators/portfolio-manager-validator.md
+++ b/docs/help_pages/validators/portfolio-manager-validator.md
@@ -30,13 +30,19 @@ members, and unsafe compression ratios are rejected.
 
 The step editor shows one matching assertion-output group:
 
-- **Single property outputs** for single property reports; or
-- **Grouped property outputs** for ZIP collections.
+- **Single property outputs** — 26 property-specific values for single property
+  reports; or
+- **Grouped property outputs** — 32 counts, coverage values, and aggregates for
+  ZIP collections.
 
 Changing the submission structure changes the available output list. If an
 existing assertion uses an output from the current group, Validibot blocks the
 change and lists the affected `o.*` values. Update or remove those assertions
 first; Validibot never silently deletes or rewrites them.
+
+Internally, the validator retains one stable 58-key scalar result contract for
+run evidence and compatibility. The grouping changes what is meaningful and
+available to authors; it does not create two backend result formats.
 
 ## Configure the workflow's validation policy
 

--- a/just/gcp/mod.just
+++ b/just/gcp/mod.just
@@ -4491,6 +4491,7 @@ _validator-state-export stage output: _require-gcp-config
 _validator-status-json stage output: _require-gcp-config
     #!/usr/bin/env bash
     set -euo pipefail
+    just gcp _maintenance-require-database {{stage}}
     WORK_DIR=$(mktemp -d)
     trap 'rm -rf "$WORK_DIR"' EXIT
     just gcp _validator-state-export {{stage}} "$WORK_DIR/database.json"
@@ -4587,20 +4588,30 @@ validator-setup stage: _require-gcp-config
     #!/usr/bin/env bash
     set -euo pipefail
     STATUS_JSON=$(mktemp)
-    trap 'rm -f "$STATUS_JSON"' EXIT
+    MAINTENANCE_ENTERED=0
+    cleanup() {
+        local status=$?
+        trap - EXIT INT TERM
+        rm -f "$STATUS_JSON"
+        if [ "$MAINTENANCE_ENTERED" = "1" ]; then
+            just gcp _enforce-maintenance {{stage}} || true
+        fi
+        exit "$status"
+    }
+    trap cleanup EXIT INT TERM
+    python3 ops/gcp/validator_release_control.py inventory
+    echo "GCP project: {{gcp_project}}"
+    echo "Region:      {{gcp_region}}"
+    read -r -p "Type the GCP project ID to continue: " REPLY
+    if [ "$REPLY" != "{{gcp_project}}" ]; then echo "Cancelled."; exit 1; fi
+    MAINTENANCE_ENTERED=1
+    GCP_YES=1 just gcp maintenance-on {{stage}}
     just gcp _validator-status-json {{stage}} "$STATUS_JSON"
     if jq -e '.backends[] | select(.active_version != null)' "$STATUS_JSON" >/dev/null; then
         echo "Error: setup is only for an installation with no active backend releases." >&2
         echo "Use validator-update to reconcile an existing installation." >&2
         exit 1
     fi
-    python3 ops/gcp/validator_release_control.py inventory
-    echo "GCP project: {{gcp_project}}"
-    echo "Region:      {{gcp_region}}"
-    read -r -p "Type the GCP project ID to continue: " REPLY
-    if [ "$REPLY" != "{{gcp_project}}" ]; then echo "Cancelled."; exit 1; fi
-    trap 'just gcp _enforce-maintenance {{stage}}' EXIT INT TERM
-    GCP_YES=1 just gcp maintenance-on {{stage}}
     for backend in energyplus fmu shacl schematron portfolio_manager; do
         VERSION=$(python3 ops/gcp/validator_release_control.py \
             inventory --backend "$backend" --field release_version)
@@ -4630,8 +4641,10 @@ validator-setup stage: _require-gcp-config
         just gcp validator-services-register "$backend" {{stage}} "$VERSION"
     done
     just gcp management-cmd {{stage}} "$GROUP_COMMAND"
-    trap - EXIT INT TERM
     GCP_YES=1 just gcp maintenance-off {{stage}}
+    MAINTENANCE_ENTERED=0
+    trap - EXIT INT TERM
+    rm -f "$STATUS_JSON"
 
 # Reconcile one backend, or every backend with a newer offered version or
 # missing semantic Validator rows. Older or rolled-back offered versions stop
@@ -5517,11 +5530,29 @@ list-weather env:
 # Maintenance Mode
 # =============================================================================
 #
-# Maintenance mode is an enforced offline state, not merely a traffic hint:
+# MAINTENANCE is an enforced runtime-isolated state, not merely a traffic hint:
 # public ingress is blocked, all services have a zero minimum, queues and
-# schedulers are paused, and Cloud SQL is stopped. The dedicated deployment
-# and management-command recipes temporarily start only the database and use
-# an EXIT trap to restore this full state after success or failure.
+# schedulers are paused, and Cloud SQL is RUNNABLE for operator work. PARKED
+# adds an explicit database stop for longer idle periods. Ordinary maintenance
+# work never stops Cloud SQL, and EXIT traps restore runtime isolation without
+# changing the database state.
+
+[private]
+_maintenance-require-database stage:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    APP_NAME="{{app_name}}"
+    if [ "{{stage}}" = "prod" ]; then DB_INSTANCE="${APP_NAME}-db"; else DB_INSTANCE="${APP_NAME}-db-{{stage}}"; fi
+    DB_STATUS=$(gcloud sql instances describe "$DB_INSTANCE" \
+        --project {{gcp_project}} --format="value(state)" 2>/dev/null || echo "unknown")
+    ACTIVE_OPERATION=$(gcloud sql operations list \
+        --instance "$DB_INSTANCE" --project {{gcp_project}} \
+        --filter="status=RUNNING" --limit=1 --format="value(name)" 2>/dev/null || echo "unknown")
+    if [ "$DB_STATUS" != "RUNNABLE" ] || [ -n "$ACTIVE_OPERATION" ]; then
+        echo "Error: Cloud SQL instance $DB_INSTANCE is not ready (state=$DB_STATUS active-operation=${ACTIVE_OPERATION:-none})." >&2
+        echo "Run 'just gcp maintenance-on {{stage}}' before this command." >&2
+        exit 1
+    fi
 
 [private]
 _maintenance-start-database stage:
@@ -5582,37 +5613,84 @@ _maintenance-assert-offline stage:
     APP_NAME="{{app_name}}"
     if [ "{{stage}}" = "prod" ]; then
         WEB_SERVICE="${APP_NAME}-web"
-        DB_INSTANCE="${APP_NAME}-db"
+        WORKER_SERVICE="${APP_NAME}-worker"
+        MCP_SERVICE="${APP_NAME}-mcp"
         QUEUE_NAME="${APP_NAME}-tasks"
         PROVIDER_QUEUE_NAME="${APP_NAME}-validator-provider"
+        JOB_SUFFIX=""
     else
         WEB_SERVICE="${APP_NAME}-web-{{stage}}"
-        DB_INSTANCE="${APP_NAME}-db-{{stage}}"
+        WORKER_SERVICE="${APP_NAME}-worker-{{stage}}"
+        MCP_SERVICE="${APP_NAME}-mcp-{{stage}}"
         QUEUE_NAME="${APP_NAME}-validation-queue-{{stage}}"
         PROVIDER_QUEUE_NAME="${APP_NAME}-validator-provider-{{stage}}"
+        JOB_SUFFIX="-{{stage}}"
     fi
-    DB_POLICY=$(gcloud sql instances describe "$DB_INSTANCE" \
-        --project {{gcp_project}} --format="value(settings.activationPolicy)" 2>/dev/null || echo "unknown")
-    INGRESS=$(gcloud run services describe "$WEB_SERVICE" \
+    ISOLATION_ERRORS=0
+    record_isolation_error() {
+        echo "Error: $*" >&2
+        ISOLATION_ERRORS=$((ISOLATION_ERRORS + 1))
+    }
+    check_isolated_service() {
+        local service="$1"
+        local expect_mcp_disabled="${2:-0}"
+        local required="${3:-0}"
+        local service_json ingress service_min revision_min mcp_enabled
+        if ! service_json=$(gcloud run services describe "$service" \
+            --region {{gcp_region}} --project {{gcp_project}} --format=json 2>/dev/null); then
+            if [ "$required" = "1" ]; then
+                record_isolation_error "required Cloud Run service $service could not be inspected."
+            fi
+            return
+        fi
+        ingress=$(jq -r '.metadata.annotations["run.googleapis.com/ingress"] // "unknown"' <<< "$service_json")
+        service_min=$(jq -r '.spec.scaling.minInstanceCount // .metadata.annotations["run.googleapis.com/minScale"] // "0"' <<< "$service_json")
+        revision_min=$(jq -r '.spec.template.metadata.annotations["autoscaling.knative.dev/minScale"] // "0"' <<< "$service_json")
+        mcp_enabled=$(jq -r '[.spec.template.spec.containers[0].env[]? | select(.name == "VALIDIBOT_MCP_ENABLED") | .value][0] // "true"' <<< "$service_json")
+        if [ "$ingress" != "internal" ] || [ "$service_min" != "0" ] || [ "$revision_min" != "0" ] || { [ "$expect_mcp_disabled" = "1" ] && [ "$mcp_enabled" != "false" ]; }; then
+            record_isolation_error "$service is not isolated (ingress=$ingress service-min=$service_min revision-min=$revision_min)."
+        fi
+    }
+    check_isolated_service "$WEB_SERVICE" 0 1
+    check_isolated_service "$WORKER_SERVICE" 0 1
+    check_isolated_service "$MCP_SERVICE" 1
+    if SERVICES=$(gcloud run services list \
         --region {{gcp_region}} --project {{gcp_project}} \
-        --format="value(metadata.annotations.'run.googleapis.com/ingress')" 2>/dev/null || echo "unknown")
+        --filter="metadata.labels.stage:{{stage}} AND metadata.labels.validator:*" \
+        --format='value(metadata.name)'); then
+        while IFS= read -r service; do
+            [ -z "$service" ] && continue
+            check_isolated_service "$service"
+        done <<< "$SERVICES"
+    else
+        record_isolation_error "validator Cloud Run services could not be listed."
+    fi
     QUEUE_STATE=$(gcloud tasks queues describe "$QUEUE_NAME" \
         --location {{gcp_region}} --project {{gcp_project}} \
         --format="value(state)" 2>/dev/null || echo "NOT_FOUND")
     PROVIDER_STATE=$(gcloud tasks queues describe "$PROVIDER_QUEUE_NAME" \
         --location {{gcp_region}} --project {{gcp_project}} \
         --format="value(state)" 2>/dev/null || echo "NOT_FOUND")
-    if [ "$DB_POLICY" != "NEVER" ] || [ "$INGRESS" != "internal" ] || [ "$QUEUE_STATE" != "PAUSED" ]; then
-        echo "Error: {{stage}} is not safely offline." >&2
-        echo "Expected DB policy NEVER, web ingress internal, and main queue PAUSED." >&2
-        echo "Observed DB=$DB_POLICY ingress=$INGRESS queue=$QUEUE_STATE." >&2
-        exit 1
+    if [ "$QUEUE_STATE" != "PAUSED" ]; then
+        record_isolation_error "main queue is $QUEUE_STATE, not PAUSED."
     fi
     if [ "$PROVIDER_STATE" != "PAUSED" ] && [ "$PROVIDER_STATE" != "NOT_FOUND" ]; then
-        echo "Error: provider queue is $PROVIDER_STATE, not PAUSED." >&2
+        record_isolation_error "provider queue is $PROVIDER_STATE, not PAUSED."
+    fi
+    for job_base in ${APP_NAME}-clear-sessions ${APP_NAME}-cleanup-idempotency-keys ${APP_NAME}-cleanup-callback-receipts ${APP_NAME}-purge-expired-submissions ${APP_NAME}-purge-expired-outputs ${APP_NAME}-process-purge-retries ${APP_NAME}-cleanup-stuck-runs ${APP_NAME}-verify-validator-deployments ${APP_NAME}-send-periodic-emails ${APP_NAME}-enforce-audit-retention ${APP_NAME}-verify-license-document-hashes; do
+        job="${job_base}${JOB_SUFFIX}"
+        state=$(gcloud scheduler jobs describe "$job" \
+            --project {{gcp_project}} --location {{gcp_region}} \
+            --format="value(state)" 2>/dev/null || echo "NOT_FOUND")
+        if [ "$state" != "PAUSED" ] && [ "$state" != "NOT_FOUND" ]; then
+            record_isolation_error "scheduler job $job is $state, not PAUSED."
+        fi
+    done
+    if [ "$ISOLATION_ERRORS" != "0" ]; then
+        echo "Error: {{stage}} runtime is not safely isolated ($ISOLATION_ERRORS issue(s))." >&2
         exit 1
     fi
-    echo "Confirmed {{stage}} is offline."
+    echo "Confirmed {{stage}} runtime is isolated."
 
 [private]
 _enforce-maintenance stage:
@@ -5623,7 +5701,6 @@ _enforce-maintenance stage:
         WEB_SERVICE="${APP_NAME}-web"
         WORKER_SERVICE="${APP_NAME}-worker"
         MCP_SERVICE="${APP_NAME}-mcp"
-        DB_INSTANCE="${APP_NAME}-db"
         QUEUE_NAME="${APP_NAME}-tasks"
         PROVIDER_QUEUE_NAME="${APP_NAME}-validator-provider"
         JOB_SUFFIX=""
@@ -5631,7 +5708,6 @@ _enforce-maintenance stage:
         WEB_SERVICE="${APP_NAME}-web-{{stage}}"
         WORKER_SERVICE="${APP_NAME}-worker-{{stage}}"
         MCP_SERVICE="${APP_NAME}-mcp-{{stage}}"
-        DB_INSTANCE="${APP_NAME}-db-{{stage}}"
         QUEUE_NAME="${APP_NAME}-validation-queue-{{stage}}"
         PROVIDER_QUEUE_NAME="${APP_NAME}-validator-provider-{{stage}}"
         JOB_SUFFIX="-{{stage}}"
@@ -5680,8 +5756,8 @@ _enforce-maintenance stage:
 
     # A failed desired revision can make even a no-op Cloud Run update fail.
     # Inspect first so already-safe services are left alone, and aggregate any
-    # update failures so queues, schedulers, and especially Cloud SQL are still
-    # shut down before this recipe returns an error.
+    # update failures so every remaining runtime and work safeguard is still
+    # attempted before this recipe returns an error.
     ensure_offline_service "$WEB_SERVICE" 0 1
     ensure_offline_service "$WORKER_SERVICE" 0 1
     ensure_offline_service "$MCP_SERVICE" 1
@@ -5718,15 +5794,30 @@ _enforce-maintenance stage:
         fi
     fi
 
-    DB_POLICY=$(gcloud sql instances describe "$DB_INSTANCE" \
-        --project {{gcp_project}} --format="value(settings.activationPolicy)" 2>/dev/null || echo "unknown")
-    DATABASE_CAN_TRANSITION=1
-    if [ "$DB_POLICY" = "unknown" ]; then
-        record_maintenance_error "Cloud SQL instance $DB_INSTANCE was not found."
-        DATABASE_CAN_TRANSITION=0
+    if [ "$MAINTENANCE_ERRORS" != "0" ]; then
+        echo "Maintenance enforcement completed all possible safeguards with $MAINTENANCE_ERRORS error(s)." >&2
+        exit 1
     fi
+    echo "{{stage}} runtime is isolated: services min=0/internal, work paused, database state unchanged."
+
+[private]
+_maintenance-stop-database stage:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    just gcp _maintenance-assert-offline {{stage}}
+    APP_NAME="{{app_name}}"
+    if [ "{{stage}}" = "prod" ]; then DB_INSTANCE="${APP_NAME}-db"; else DB_INSTANCE="${APP_NAME}-db-{{stage}}"; fi
+    DB_STATUS=$(gcloud sql instances describe "$DB_INSTANCE" \
+        --project {{gcp_project}} --format="value(state)" 2>/dev/null || echo "unknown")
+    if [ "$DB_STATUS" = "unknown" ]; then
+        echo "Error: Cloud SQL instance $DB_INSTANCE was not found." >&2
+        exit 1
+    fi
+    DB_POLICY=$(gcloud sql instances describe "$DB_INSTANCE" \
+        --project {{gcp_project}} --format="value(settings.activationPolicy)")
     DEADLINE=$((SECONDS + ${GCP_SQL_TRANSITION_TIMEOUT_SECONDS:-1800}))
-    if [ "$DATABASE_CAN_TRANSITION" = "1" ] && [ "$DB_POLICY" != "NEVER" ]; then
+    if [ "$DB_POLICY" != "NEVER" ]; then
+        echo "Stopping Cloud SQL instance $DB_INSTANCE..."
         PATCH_SUBMITTED=0
         while [ "$SECONDS" -lt "$DEADLINE" ]; do
             if PATCH_OUTPUT=$(gcloud sql instances patch "$DB_INSTANCE" \
@@ -5736,45 +5827,33 @@ _enforce-maintenance stage:
             fi
             if [[ "$PATCH_OUTPUT" != *"another operation was already in progress"* ]]; then
                 echo "$PATCH_OUTPUT" >&2
-                record_maintenance_error "could not submit the Cloud SQL stop operation."
-                DATABASE_CAN_TRANSITION=0
-                break
+                exit 1
             fi
             echo "Waiting for the active Cloud SQL operation before stopping $DB_INSTANCE..."
             sleep 10
         done
-        if [ "$DATABASE_CAN_TRANSITION" = "1" ] && [ "$PATCH_SUBMITTED" != "1" ]; then
-            record_maintenance_error "could not submit the Cloud SQL stop operation within the transition timeout."
-            DATABASE_CAN_TRANSITION=0
+        if [ "$PATCH_SUBMITTED" != "1" ]; then
+            echo "Error: could not submit the Cloud SQL stop operation within the transition timeout." >&2
+            exit 1
         fi
     fi
-    DATABASE_STOPPED=0
-    if [ "$DATABASE_CAN_TRANSITION" = "1" ]; then
-        while [ "$SECONDS" -lt "$DEADLINE" ]; do
-            DB_STATUS=$(gcloud sql instances describe "$DB_INSTANCE" \
-                --project {{gcp_project}} --format="value(state)" 2>/dev/null || echo "unknown")
-            ACTIVE_OPERATION=$(gcloud sql operations list \
-                --instance "$DB_INSTANCE" --project {{gcp_project}} \
-                --filter="status=RUNNING" --limit=1 --format="value(name)" 2>/dev/null || echo "unknown")
-            if [ "$DB_STATUS" = "STOPPED" ] && [ -z "$ACTIVE_OPERATION" ]; then
-                DATABASE_STOPPED=1
-                break
-            fi
-            echo "Waiting for Cloud SQL to stop (state=$DB_STATUS active-operation=${ACTIVE_OPERATION:-none})..."
-            sleep 10
-        done
-        if [ "$DATABASE_STOPPED" != "1" ]; then
-            record_maintenance_error "Cloud SQL instance $DB_INSTANCE did not stop within the transition timeout."
+    while [ "$SECONDS" -lt "$DEADLINE" ]; do
+        DB_STATUS=$(gcloud sql instances describe "$DB_INSTANCE" \
+            --project {{gcp_project}} --format="value(state)" 2>/dev/null || echo "unknown")
+        ACTIVE_OPERATION=$(gcloud sql operations list \
+            --instance "$DB_INSTANCE" --project {{gcp_project}} \
+            --filter="status=RUNNING" --limit=1 --format="value(name)" 2>/dev/null || echo "unknown")
+        if [ "$DB_STATUS" = "STOPPED" ] && [ -z "$ACTIVE_OPERATION" ]; then
+            echo "Cloud SQL instance $DB_INSTANCE is stopped."
+            exit 0
         fi
-    fi
+        echo "Waiting for Cloud SQL to stop (state=$DB_STATUS active-operation=${ACTIVE_OPERATION:-none})..."
+        sleep 10
+    done
+    echo "Error: Cloud SQL instance $DB_INSTANCE did not become STOPPED within the transition timeout." >&2
+    exit 1
 
-    if [ "$MAINTENANCE_ERRORS" != "0" ]; then
-        echo "Maintenance enforcement completed all possible safeguards with $MAINTENANCE_ERRORS error(s)." >&2
-        exit 1
-    fi
-    echo "{{stage}} is in maintenance mode: services min=0/internal, work paused, database stopped."
-
-# Put a stage into maintenance mode (pause and scale down all resources).
+# Put a stage into maintenance mode: isolate runtime and keep its database ready.
 [arg('stage', pattern='dev|staging|prod')]
 maintenance-on stage: _require-gcp-config
     #!/usr/bin/env bash
@@ -5784,7 +5863,27 @@ maintenance-on stage: _require-gcp-config
         read -r -p "Type 'yes' to confirm: " REPLY
         if [ "$REPLY" != "yes" ]; then echo "Cancelled."; exit 1; fi
     fi
+    trap 'just gcp _enforce-maintenance {{stage}}' EXIT
     just gcp _enforce-maintenance {{stage}}
+    just gcp _maintenance-start-database {{stage}}
+    trap - EXIT
+    echo "{{stage}} is in MAINTENANCE: runtime isolated, work paused, database available."
+
+# Park an already isolated stage by explicitly stopping its database.
+[arg('stage', pattern='dev|staging|prod')]
+maintenance-park stage: _require-gcp-config
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if [ "{{stage}}" = "prod" ] && [ "${GCP_YES:-0}" != "1" ]; then
+        echo "WARNING: This will stop the PRODUCTION database while keeping the runtime isolated."
+        read -r -p "Type 'park' to confirm: " REPLY
+        if [ "$REPLY" != "park" ]; then echo "Cancelled."; exit 1; fi
+    fi
+    trap 'just gcp _enforce-maintenance {{stage}}' EXIT
+    just gcp _enforce-maintenance {{stage}}
+    just gcp _maintenance-stop-database {{stage}}
+    trap - EXIT
+    echo "{{stage}} is PARKED: runtime isolated, work paused, database stopped."
 
 # Reconcile existing stage infrastructure while preserving maintenance mode.
 [arg('stage', pattern='dev|staging|prod')]
@@ -5799,8 +5898,8 @@ init-stage-maintenance stage: _require-gcp-config
     trap - EXIT
 
 # Build and deploy the newest app revision without bringing the stage online.
-# Only Cloud SQL is temporarily started for migrations; an EXIT trap restores
-# full maintenance mode even if a build, migration, or deployment fails.
+# Cloud SQL stays available for maintenance work; an EXIT trap restores runtime
+# isolation even if a build, migration, or deployment fails.
 [arg('stage', pattern='dev|staging|prod')]
 deploy-maintenance stage: _require-gcp-config
     #!/usr/bin/env bash
@@ -5937,7 +6036,7 @@ maintenance-off stage: _require-gcp-config
     fi
     echo "{{stage}} is online: database ready, service capacity restored, work resumed."
 
-# Report the signals that define maintenance mode.
+# Report whether a stage is online, in maintenance, parked, or mid-transition.
 [arg('stage', pattern='dev|staging|prod')]
 maintenance-status stage: _require-gcp-config
     #!/usr/bin/env bash
@@ -5960,13 +6059,6 @@ maintenance-status stage: _require-gcp-config
         PROVIDER_QUEUE_NAME="${APP_NAME}-validator-provider-{{stage}}"
         JOB_SUFFIX="-{{stage}}"
     fi
-    INGRESS=$(gcloud run services describe "$WEB_SERVICE" \
-        --region {{gcp_region}} --project {{gcp_project}} \
-        --format="value(metadata.annotations.'run.googleapis.com/ingress')" 2>/dev/null || echo "unknown")
-    WEB_JSON=$(gcloud run services describe "$WEB_SERVICE" \
-        --region {{gcp_region}} --project {{gcp_project}} --format=json)
-    WEB_SERVICE_MIN=$(jq -r '.spec.scaling.minInstanceCount // .metadata.annotations["run.googleapis.com/minScale"] // "0"' <<< "$WEB_JSON")
-    WEB_REVISION_MIN=$(jq -r '.spec.template.metadata.annotations["autoscaling.knative.dev/minScale"] // "0"' <<< "$WEB_JSON")
     DB_STATUS=$(gcloud sql instances describe "$DB_INSTANCE" \
         --project {{gcp_project}} --format="value(state)" 2>/dev/null || echo "unknown")
     DB_ACTIVE_OPERATION=$(gcloud sql operations list \
@@ -5978,24 +6070,37 @@ maintenance-status stage: _require-gcp-config
     PROVIDER_STATUS=$(gcloud tasks queues describe "$PROVIDER_QUEUE_NAME" \
         --location {{gcp_region}} --project {{gcp_project}} \
         --format="value(state)" 2>/dev/null || echo "NOT_FOUND")
-    WEB_SERVICE_MIN="${WEB_SERVICE_MIN:-0}"
-    WEB_REVISION_MIN="${WEB_REVISION_MIN:-0}"
+    WEB_INGRESS="unknown"
+    WEB_SERVICE_MIN="unknown"
+    WEB_REVISION_MIN="unknown"
     RUNTIME_ISSUES=0
-    check_offline_service() {
+    RUNTIME_INSPECTION_ERRORS=0
+    echo "Stage status for {{stage}}"
+    check_service() {
         local service="$1"
         local expect_mcp_disabled="${2:-0}"
-        if ! gcloud run services describe "$service" --region {{gcp_region}} --project {{gcp_project}} &>/dev/null; then
+        local required="${3:-0}"
+        local service_json ingress service_min revision_min mcp_enabled
+        if ! service_json=$(gcloud run services describe "$service" \
+            --region {{gcp_region}} --project {{gcp_project}} --format=json 2>/dev/null); then
+            if [ "$required" = "1" ]; then
+                echo "  Runtime:       $service could not be inspected"
+                RUNTIME_ISSUES=$((RUNTIME_ISSUES + 1))
+                RUNTIME_INSPECTION_ERRORS=$((RUNTIME_INSPECTION_ERRORS + 1))
+            else
+                echo "  Runtime:       $service not present"
+            fi
             return
         fi
-        local ingress service_min revision_min service_json mcp_enabled
-        ingress=$(gcloud run services describe "$service" \
-            --region {{gcp_region}} --project {{gcp_project}} \
-            --format="value(metadata.annotations.'run.googleapis.com/ingress')")
-        service_json=$(gcloud run services describe "$service" \
-            --region {{gcp_region}} --project {{gcp_project}} --format=json)
+        ingress=$(jq -r '.metadata.annotations["run.googleapis.com/ingress"] // "unknown"' <<< "$service_json")
         service_min=$(jq -r '.spec.scaling.minInstanceCount // .metadata.annotations["run.googleapis.com/minScale"] // "0"' <<< "$service_json")
         revision_min=$(jq -r '.spec.template.metadata.annotations["autoscaling.knative.dev/minScale"] // "0"' <<< "$service_json")
         mcp_enabled=$(jq -r '[.spec.template.spec.containers[0].env[]? | select(.name == "VALIDIBOT_MCP_ENABLED") | .value][0] // "true"' <<< "$service_json")
+        if [ "$service" = "$WEB_SERVICE" ]; then
+            WEB_INGRESS="$ingress"
+            WEB_SERVICE_MIN="$service_min"
+            WEB_REVISION_MIN="$revision_min"
+        fi
         if [ "$expect_mcp_disabled" = "1" ]; then
             echo "  Runtime:       $service ingress=$ingress service-min=$service_min revision-min=$revision_min enabled=$mcp_enabled"
         else
@@ -6005,38 +6110,55 @@ maintenance-status stage: _require-gcp-config
             RUNTIME_ISSUES=$((RUNTIME_ISSUES + 1))
         fi
     }
-    check_offline_service "$WORKER_SERVICE"
-    check_offline_service "$MCP_SERVICE" 1
-    SERVICES=$(gcloud run services list \
+    check_service "$WEB_SERVICE" 0 1
+    check_service "$WORKER_SERVICE" 0 1
+    check_service "$MCP_SERVICE" 1
+    if SERVICES=$(gcloud run services list \
         --region {{gcp_region}} --project {{gcp_project}} \
         --filter="metadata.labels.stage:{{stage}} AND metadata.labels.validator:*" \
-        --format='value(metadata.name)')
-    while IFS= read -r service; do
-        [ -z "$service" ] && continue
-        check_offline_service "$service"
-    done <<< "$SERVICES"
+        --format='value(metadata.name)'); then
+        while IFS= read -r service; do
+            [ -z "$service" ] && continue
+            check_service "$service"
+        done <<< "$SERVICES"
+    else
+        echo "  Runtime:       validator services could not be listed"
+        RUNTIME_ISSUES=$((RUNTIME_ISSUES + 1))
+        RUNTIME_INSPECTION_ERRORS=$((RUNTIME_INSPECTION_ERRORS + 1))
+    fi
     SCHEDULER_ACTIVE=0
+    SCHEDULER_PAUSED=0
     for job_base in ${APP_NAME}-clear-sessions ${APP_NAME}-cleanup-idempotency-keys ${APP_NAME}-cleanup-callback-receipts ${APP_NAME}-purge-expired-submissions ${APP_NAME}-purge-expired-outputs ${APP_NAME}-process-purge-retries ${APP_NAME}-cleanup-stuck-runs ${APP_NAME}-verify-validator-deployments ${APP_NAME}-send-periodic-emails ${APP_NAME}-enforce-audit-retention ${APP_NAME}-verify-license-document-hashes; do
         job="${job_base}${JOB_SUFFIX}"
         state=$(gcloud scheduler jobs describe "$job" \
             --project {{gcp_project}} --location {{gcp_region}} \
             --format="value(state)" 2>/dev/null || echo "NOT_FOUND")
-        if [ "$state" != "PAUSED" ] && [ "$state" != "NOT_FOUND" ]; then
+        if [ "$state" = "PAUSED" ]; then
+            SCHEDULER_PAUSED=$((SCHEDULER_PAUSED + 1))
+        elif [ "$state" != "NOT_FOUND" ]; then
             SCHEDULER_ACTIVE=$((SCHEDULER_ACTIVE + 1))
         fi
     done
-    echo "Maintenance status for {{stage}}"
-    echo "  Web ingress:   $INGRESS"
+    echo "  Web ingress:   $WEB_INGRESS"
     echo "  Web minimum:   service=$WEB_SERVICE_MIN revision=$WEB_REVISION_MIN"
     echo "  Database:      $DB_STATUS"
     echo "  DB operation:  ${DB_ACTIVE_OPERATION:-none}"
     echo "  Main queue:    $QUEUE_STATUS"
     echo "  Provider queue: $PROVIDER_STATUS"
     echo "  Active schedulers: $SCHEDULER_ACTIVE"
-    if [ "$INGRESS" = "internal" ] && [ "$WEB_SERVICE_MIN" = "0" ] && [ "$WEB_REVISION_MIN" = "0" ] && [ "$DB_STATUS" = "STOPPED" ] && [ -z "$DB_ACTIVE_OPERATION" ] && [ "$QUEUE_STATUS" = "PAUSED" ] && [ "$RUNTIME_ISSUES" = "0" ] && [ "$SCHEDULER_ACTIVE" = "0" ] && { [ "$PROVIDER_STATUS" = "PAUSED" ] || [ "$PROVIDER_STATUS" = "NOT_FOUND" ]; }; then
-        echo "  Overall:       MAINTENANCE (safely offline)"
+    echo "  Paused schedulers: $SCHEDULER_PAUSED"
+    RUNTIME_ISOLATED=0
+    if [ "$WEB_INGRESS" = "internal" ] && [ "$WEB_SERVICE_MIN" = "0" ] && [ "$WEB_REVISION_MIN" = "0" ] && [ "$QUEUE_STATUS" = "PAUSED" ] && [ "$RUNTIME_ISSUES" = "0" ] && [ "$SCHEDULER_ACTIVE" = "0" ] && { [ "$PROVIDER_STATUS" = "PAUSED" ] || [ "$PROVIDER_STATUS" = "NOT_FOUND" ]; }; then
+        RUNTIME_ISOLATED=1
+    fi
+    if [ "$RUNTIME_ISOLATED" = "1" ] && [ "$DB_STATUS" = "RUNNABLE" ] && [ -z "$DB_ACTIVE_OPERATION" ]; then
+        echo "  Overall:       MAINTENANCE (isolated, database available)"
+    elif [ "$RUNTIME_ISOLATED" = "1" ] && [ "$DB_STATUS" = "STOPPED" ] && [ -z "$DB_ACTIVE_OPERATION" ]; then
+        echo "  Overall:       PARKED (isolated, database stopped)"
+    elif [ "$RUNTIME_INSPECTION_ERRORS" = "0" ] && [ "$DB_STATUS" = "RUNNABLE" ] && [ -z "$DB_ACTIVE_OPERATION" ] && [ "$WEB_INGRESS" != "internal" ] && [ "$WEB_INGRESS" != "unknown" ] && [ "$QUEUE_STATUS" = "RUNNING" ] && [ "$SCHEDULER_PAUSED" = "0" ] && { [ "$PROVIDER_STATUS" = "RUNNING" ] || [ "$PROVIDER_STATUS" = "NOT_FOUND" ]; }; then
+        echo "  Overall:       ONLINE"
     else
-        echo "  Overall:       ONLINE OR PARTIALLY TRANSITIONED"
+        echo "  Overall:       PARTIALLY TRANSITIONED"
     fi
     echo ""
 

--- a/just/gcp/mod.just
+++ b/just/gcp/mod.just
@@ -109,30 +109,67 @@ _require-gcp-config:
         exit 1
     fi
 
-# Helper to block deploys when a stage is in maintenance mode.
-# Checks the Cloud SQL instance status — if it's stopped, maintenance is on.
+# Require the complete LIVE lifecycle state before an ordinary deploy or other
+# online-only operation. Database availability alone is insufficient because
+# MAINTENANCE deliberately keeps Cloud SQL running while runtime ingress,
+# queues, and schedulers remain isolated.
 [private]
-_require-not-maintenance stage:
+_mode-require-live stage:
     #!/usr/bin/env bash
     set -euo pipefail
-    APP_NAME="{{app_name}}"
-    if [ "{{stage}}" = "prod" ]; then
-        DB_INSTANCE="${APP_NAME}-db"
-    else
-        DB_INSTANCE="${APP_NAME}-db-{{stage}}"
-    fi
-    DB_STATUS=$(gcloud sql instances describe "$DB_INSTANCE" \
-        --project {{gcp_project}} \
-        --format="value(state)" 2>/dev/null || echo "unknown")
-    if [ "$DB_STATUS" != "RUNNABLE" ]; then
-        echo "Error: {{stage}} is in maintenance mode (database is $DB_STATUS)."
+    MODE=$(just gcp _mode-current {{stage}})
+    if [ "$MODE" != "LIVE" ]; then
+        echo "Error: {{stage}} is not LIVE (current mode: $MODE)."
         echo ""
-        echo "Deploying while maintenance is on would leave services unable to"
-        echo "reach the database. Bring the stage online first:"
+        echo "This command is blocked unless every lifecycle signal is healthy:"
+        echo "database ready, public runtime restored, queues running, and managed"
+        echo "scheduler jobs active. Inspect and reconcile the stage first:"
         echo ""
-        echo "  just gcp maintenance-off {{stage}}"
+        echo "  just gcp mode-status {{stage}}"
+        echo "  just gcp mode-live {{stage}}"
         exit 1
     fi
+
+# Print the reconciled lifecycle mode for a stage. The public status recipe
+# remains intentionally verbose for operators; callers use this small helper
+# when they need a machine-readable decision.
+[private]
+_mode-current stage:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    STATUS=$(just gcp mode-status {{stage}})
+    MODE=$(awk '/^[[:space:]]*Overall:/ {print $2; exit}' <<< "$STATUS")
+    case "$MODE" in
+        LIVE|MAINTENANCE|PARKED)
+            printf '%s\n' "$MODE"
+            ;;
+        *)
+            printf '%s\n' "PARTIALLY_TRANSITIONED"
+            ;;
+    esac
+
+# Return a stage to the lifecycle state captured by a higher-level operation.
+# Validator workflows use this after their isolated work completes so they do
+# not accidentally convert a PARKED or MAINTENANCE stage into LIVE.
+[private]
+_mode-restore stage mode:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    case "{{mode}}" in
+        LIVE)
+            GCP_YES=1 just gcp mode-live {{stage}}
+            ;;
+        MAINTENANCE)
+            GCP_YES=1 just gcp mode-maintenance {{stage}}
+            ;;
+        PARKED)
+            GCP_YES=1 just gcp mode-parked {{stage}}
+            ;;
+        *)
+            echo "Error: cannot restore unknown lifecycle mode '{{mode}}'." >&2
+            exit 1
+            ;;
+    esac
 
 # Git SHA for image tagging (inherited from common.just via root justfile)
 git_sha := `git rev-parse --short HEAD`
@@ -504,7 +541,7 @@ _confirm-deploy stage:
     fi
 
 [arg('stage', pattern='dev|staging|prod')]
-deploy stage: _require-gcp-config (_confirm-deploy stage) (_require-not-maintenance stage) build push (_maybe-migrate stage) (_deploy-web stage)
+deploy stage: _require-gcp-config (_confirm-deploy stage) (_mode-require-live stage) build push (_maybe-migrate stage) (_deploy-web stage)
 
 # Deploy worker service to a specific stage.
 # The worker handles background tasks triggered by Cloud Tasks.
@@ -519,7 +556,7 @@ deploy stage: _require-gcp-config (_confirm-deploy stage) (_require-not-maintena
 #
 # Usage: just gcp deploy-worker dev | just gcp deploy-worker prod
 [arg('stage', pattern='dev|staging|prod')]
-deploy-worker stage: _require-gcp-config (_confirm-deploy stage) (_require-not-maintenance stage) build push (_maybe-migrate stage) (_deploy-worker stage)
+deploy-worker stage: _require-gcp-config (_confirm-deploy stage) (_mode-require-live stage) build push (_maybe-migrate stage) (_deploy-worker stage)
 
 # Deploy every service to a stage (single build+push for Django, plus
 # an MCP build+deploy when ENABLE_MCP_SERVER is set).
@@ -551,7 +588,7 @@ deploy-worker stage: _require-gcp-config (_confirm-deploy stage) (_require-not-m
 # Usage (with MCP, ad-hoc): ENABLE_MCP_SERVER=true just gcp deploy-all prod
 # Usage (with MCP, persisted via .build file): just gcp deploy-all prod
 [arg('stage', pattern='dev|staging|prod')]
-deploy-all stage: _require-gcp-config (_confirm-deploy stage) (_require-not-maintenance stage) build push (_maybe-migrate stage) (_deploy-web stage) (_deploy-worker stage) (scheduler-setup stage) (_maybe-deploy-mcp stage)
+deploy-all stage: _require-gcp-config (_confirm-deploy stage) (_mode-require-live stage) build push (_maybe-migrate stage) (_deploy-web stage) (_deploy-worker stage) (scheduler-setup stage) (_maybe-deploy-mcp stage)
     @echo ""
     @echo "All services deployed to {{stage}}"
     @echo ""
@@ -2166,7 +2203,7 @@ _run-backup stage image:
 #     surface (``data-only`` / ``config-only`` / ``full``).
 #   - Active maintenance-mode toggling.  Cloud SQL import takes
 #     the DB offline briefly; the operator can ``just gcp
-#     maintenance-on`` first if they want to be explicit.
+#     mode-maintenance`` first if they want to be explicit.
 [private]
 _run-restore stage path image:
     #!/usr/bin/env bash
@@ -2396,7 +2433,7 @@ _run-restore stage path image:
 
     # ── Step 1: Cloud SQL import ───────────────────────────────────────
     # Cloud SQL takes the DB offline during import; running services
-    # queue requests.  The operator can ``just gcp maintenance-on``
+    # queue requests.  The operator can ``just gcp mode-maintenance``
     # first if they want a clean drain.
     echo "Step 1/3: Importing Cloud SQL database from ${DB_OBJECT}..."
     gcloud sql import sql "${DB_INSTANCE}" "${DB_OBJECT}" \
@@ -2705,21 +2742,22 @@ init-stage stage: _require-gcp-config
     SA_EMAIL="$SA_NAME@{{gcp_project}}.iam.gserviceaccount.com"
     PROVIDER_INVOKER_EMAIL="$PROVIDER_INVOKER_NAME@{{gcp_project}}.iam.gserviceaccount.com"
 
-    # ``init-stage`` is the low-level bootstrap path and needs a running
-    # existing database to inspect/create its database and user.  An offline
-    # stage deliberately has activationPolicy=NEVER; fail before making any
-    # partial changes and direct the operator to the wrapper that briefly
-    # starts Cloud SQL and restores maintenance mode on every exit.
+    # ``init-stage`` is the low-level bootstrap path. Existing infrastructure
+    # may only be reconciled while the complete stage is LIVE. Database state
+    # alone is not sufficient: MAINTENANCE deliberately leaves Cloud SQL
+    # RUNNABLE while runtime traffic, queues, and schedulers stay isolated.
+    # The maintenance wrapper opts into this path only after proving isolation
+    # and arranging fail-closed cleanup.
     if gcloud sql instances describe "$DB_INSTANCE" \
         --project={{gcp_project}} &>/dev/null; then
-        DB_ACTIVATION_POLICY=$(gcloud sql instances describe "$DB_INSTANCE" \
-            --project={{gcp_project}} \
-            --format="value(settings.activationPolicy)")
-        if [ "$DB_ACTIVATION_POLICY" = "NEVER" ]; then
-            echo "Error: $DB_INSTANCE is stopped for maintenance." >&2
-            echo "Use the maintenance-safe wrapper instead:" >&2
-            echo "  just gcp init-stage-maintenance {{stage}}" >&2
-            exit 1
+        if [ "${GCP_INIT_STAGE_MAINTENANCE:-0}" != "1" ]; then
+            CURRENT_MODE=$(just gcp _mode-current {{stage}})
+            if [ "$CURRENT_MODE" != "LIVE" ]; then
+                echo "Error: existing stage {{stage}} is not LIVE (current mode: $CURRENT_MODE)." >&2
+                echo "Use the maintenance-safe wrapper to reconcile it without opening traffic:" >&2
+                echo "  just gcp init-stage-maintenance {{stage}}" >&2
+                exit 1
+            fi
         fi
     fi
 
@@ -4588,29 +4626,52 @@ validator-setup stage: _require-gcp-config
     #!/usr/bin/env bash
     set -euo pipefail
     STATUS_JSON=$(mktemp)
-    MAINTENANCE_ENTERED=0
+    INITIAL_MODE=$(just gcp _mode-current {{stage}})
+    case "$INITIAL_MODE" in
+        LIVE|MAINTENANCE|PARKED) ;;
+        *)
+            echo "Error: {{stage}} is PARTIALLY_TRANSITIONED; reconcile it before validator setup." >&2
+            exit 1
+            ;;
+    esac
+    MODE_CHANGED=0
     cleanup() {
         local status=$?
         trap - EXIT INT TERM
-        rm -f "$STATUS_JSON"
-        if [ "$MAINTENANCE_ENTERED" = "1" ]; then
-            just gcp _enforce-maintenance {{stage}} || true
+        if [ "$MODE_CHANGED" = "1" ]; then
+            if ! just gcp _mode-restore {{stage}} "$INITIAL_MODE"; then
+                echo "Error: failed to restore {{stage}} to its initial $INITIAL_MODE mode." >&2
+                just gcp _enforce-maintenance {{stage}} || true
+                status=1
+            fi
         fi
+        rm -f "$STATUS_JSON"
         exit "$status"
     }
     trap cleanup EXIT INT TERM
+    ensure_uninstalled() {
+        just gcp _validator-status-json {{stage}} "$STATUS_JSON"
+        if jq -e '.backends[] | select(.active_version != null)' "$STATUS_JSON" >/dev/null; then
+            echo "Error: setup is only for an installation with no active backend releases." >&2
+            echo "Use validator-update to reconcile an existing installation." >&2
+            return 1
+        fi
+    }
     python3 ops/gcp/validator_release_control.py inventory
     echo "GCP project: {{gcp_project}}"
     echo "Region:      {{gcp_region}}"
     read -r -p "Type the GCP project ID to continue: " REPLY
     if [ "$REPLY" != "{{gcp_project}}" ]; then echo "Cancelled."; exit 1; fi
-    MAINTENANCE_ENTERED=1
-    GCP_YES=1 just gcp maintenance-on {{stage}}
-    just gcp _validator-status-json {{stage}} "$STATUS_JSON"
-    if jq -e '.backends[] | select(.active_version != null)' "$STATUS_JSON" >/dev/null; then
-        echo "Error: setup is only for an installation with no active backend releases." >&2
-        echo "Use validator-update to reconcile an existing installation." >&2
-        exit 1
+    # LIVE and MAINTENANCE have a usable database, so reject an existing
+    # installation before changing any lifecycle signal. PARKED must first
+    # enter MAINTENANCE because its database is deliberately stopped.
+    if [ "$INITIAL_MODE" != "PARKED" ]; then
+        ensure_uninstalled
+    fi
+    MODE_CHANGED=1
+    GCP_YES=1 just gcp mode-maintenance {{stage}}
+    if [ "$INITIAL_MODE" = "PARKED" ]; then
+        ensure_uninstalled
     fi
     for backend in energyplus fmu shacl schematron portfolio_manager; do
         VERSION=$(python3 ops/gcp/validator_release_control.py \
@@ -4641,8 +4702,8 @@ validator-setup stage: _require-gcp-config
         just gcp validator-services-register "$backend" {{stage}} "$VERSION"
     done
     just gcp management-cmd {{stage}} "$GROUP_COMMAND"
-    GCP_YES=1 just gcp maintenance-off {{stage}}
-    MAINTENANCE_ENTERED=0
+    just gcp _mode-restore {{stage}} "$INITIAL_MODE"
+    MODE_CHANGED=0
     trap - EXIT INT TERM
     rm -f "$STATUS_JSON"
 
@@ -4654,7 +4715,47 @@ validator-update stage backend="": _require-gcp-config
     #!/usr/bin/env bash
     set -euo pipefail
     WORK_DIR=$(mktemp -d)
-    trap 'rm -rf "$WORK_DIR"' EXIT
+    INITIAL_MODE=$(just gcp _mode-current {{stage}})
+    case "$INITIAL_MODE" in
+        LIVE|MAINTENANCE|PARKED) ;;
+        *)
+            echo "Error: {{stage}} is PARTIALLY_TRANSITIONED; reconcile it before validator update." >&2
+            exit 1
+            ;;
+    esac
+    MODE_CHANGED=0
+    BACKENDS=()
+    restore_previous_routes() {
+        local status=$?
+        trap - EXIT INT TERM
+        if [ "$status" -ne 0 ]; then
+            for selected_backend in "${BACKENDS[@]}"; do
+                old_version=$(jq -r --arg backend "$selected_backend" \
+                    '.[] | select(.backend == $backend) | .active_version // ""' \
+                    "$WORK_DIR/selected.json")
+                if [ -n "$old_version" ]; then
+                    just gcp validator-backend-route "$selected_backend" {{stage}} \
+                        "$old_version" normal ACCEPTANCE_FAILURE || true
+                fi
+            done
+        fi
+        if [ "$MODE_CHANGED" = "1" ]; then
+            if ! just gcp _mode-restore {{stage}} "$INITIAL_MODE"; then
+                echo "Error: failed to restore {{stage}} to its initial $INITIAL_MODE mode." >&2
+                just gcp _enforce-maintenance {{stage}} || true
+                status=1
+            fi
+        fi
+        rm -rf "$WORK_DIR"
+        exit "$status"
+    }
+    trap restore_previous_routes EXIT INT TERM
+    # A parked database cannot serve the read-only release preflight. Starting
+    # it remains isolated and is restored to PARKED by the trap on every exit.
+    if [ "$INITIAL_MODE" = "PARKED" ]; then
+        MODE_CHANGED=1
+        GCP_YES=1 just gcp mode-maintenance {{stage}}
+    fi
     just gcp _validator-status-json {{stage}} "$WORK_DIR/status.json"
     if [ -n "{{backend}}" ]; then
         jq --arg backend "{{backend}}" \
@@ -4681,29 +4782,11 @@ validator-update stage backend="": _require-gcp-config
     if [ -z "$CONFIRM" ]; then CONFIRM="update"; fi
     read -r -p "Type $CONFIRM to continue: " REPLY
     if [ "$REPLY" != "$CONFIRM" ]; then echo "Cancelled."; exit 1; fi
-    BACKENDS=()
     while IFS= read -r selected_backend; do
         BACKENDS+=("$selected_backend")
     done < <(jq -r '.[].backend' "$WORK_DIR/selected.json")
-    restore_previous_routes() {
-        local status=$?
-        trap - EXIT INT TERM
-        if [ "$status" -ne 0 ]; then
-            for selected_backend in "${BACKENDS[@]}"; do
-                old_version=$(jq -r --arg backend "$selected_backend" \
-                    '.[] | select(.backend == $backend) | .active_version // ""' \
-                    "$WORK_DIR/selected.json")
-                if [ -n "$old_version" ]; then
-                    just gcp validator-backend-route "$selected_backend" {{stage}} \
-                        "$old_version" normal ACCEPTANCE_FAILURE || true
-                fi
-            done
-            just gcp _enforce-maintenance {{stage}} || true
-        fi
-        exit "$status"
-    }
-    trap restore_previous_routes EXIT INT TERM
-    GCP_YES=1 just gcp maintenance-on {{stage}}
+    MODE_CHANGED=1
+    GCP_YES=1 just gcp mode-maintenance {{stage}}
     for selected_backend in "${BACKENDS[@]}"; do
         version=$(jq -r --arg backend "$selected_backend" \
             '.[] | select(.backend == $backend) | .file_version' \
@@ -4762,8 +4845,10 @@ validator-update stage backend="": _require-gcp-config
         just gcp validator-services-register "$selected_backend" {{stage}} "$version"
     done
     just gcp management-cmd {{stage}} "$GROUP_COMMAND"
+    just gcp _mode-restore {{stage}} "$INITIAL_MODE"
+    MODE_CHANGED=0
     trap - EXIT INT TERM
-    GCP_YES=1 just gcp maintenance-off {{stage}}
+    rm -rf "$WORK_DIR"
 
 # Roll back one backend release, enter Job-only mode, restore normal mode, or
 # recover an exact version previously accepted by this installation.
@@ -4772,7 +4857,33 @@ validator-rollback stage backend operation="release": _require-gcp-config
     #!/usr/bin/env bash
     set -euo pipefail
     WORK_DIR=$(mktemp -d)
-    trap 'rm -rf "$WORK_DIR"' EXIT
+    INITIAL_MODE=$(just gcp _mode-current {{stage}})
+    case "$INITIAL_MODE" in
+        LIVE|MAINTENANCE|PARKED) ;;
+        *)
+            echo "Error: {{stage}} is PARTIALLY_TRANSITIONED; reconcile it before validator rollback." >&2
+            exit 1
+            ;;
+    esac
+    MODE_CHANGED=0
+    restore_initial_mode() {
+        local status=$?
+        trap - EXIT INT TERM
+        if [ "$MODE_CHANGED" = "1" ]; then
+            if ! just gcp _mode-restore {{stage}} "$INITIAL_MODE"; then
+                echo "Error: failed to restore {{stage}} to its initial $INITIAL_MODE mode." >&2
+                just gcp _enforce-maintenance {{stage}} || true
+                status=1
+            fi
+        fi
+        rm -rf "$WORK_DIR"
+        exit "$status"
+    }
+    trap restore_initial_mode EXIT INT TERM
+    if [ "$INITIAL_MODE" = "PARKED" ]; then
+        MODE_CHANGED=1
+        GCP_YES=1 just gcp mode-maintenance {{stage}}
+    fi
     just gcp _validator-status-json {{stage}} "$WORK_DIR/status.json"
     CURRENT=$(jq -r --arg backend "{{backend}}" \
         '.backends[] | select(.backend == $backend) | .active_version // ""' \
@@ -4840,8 +4951,8 @@ validator-rollback stage backend operation="release": _require-gcp-config
     echo "{{backend}}: $CURRENT -> $TARGET ($MODE)"
     read -r -p "Type {{backend}} to continue: " REPLY
     if [ "$REPLY" != "{{backend}}" ]; then echo "Cancelled."; exit 1; fi
-    trap 'just gcp _enforce-maintenance {{stage}}' EXIT INT TERM
-    GCP_YES=1 just gcp maintenance-on {{stage}}
+    MODE_CHANGED=1
+    GCP_YES=1 just gcp mode-maintenance {{stage}}
     if [ "{{operation}}" != "job-mode" ] && [ "{{operation}}" != "normal-mode" ]; then
         SOURCE_TAG="{{backend}}-v${TARGET}"
         VALIDATOR_ALLOW_HISTORICAL=1 \
@@ -4854,8 +4965,10 @@ validator-rollback stage backend operation="release": _require-gcp-config
     fi
     just gcp validator-backend-route "{{backend}}" {{stage}} "$TARGET" "$MODE" \
         "$CAUSE" "" "$RECOVERY_REASON_B64"
+    just gcp _mode-restore {{stage}} "$INITIAL_MODE"
+    MODE_CHANGED=0
     trap - EXIT INT TERM
-    GCP_YES=1 just gcp maintenance-off {{stage}}
+    rm -rf "$WORK_DIR"
 
 # Calculate an exact seven-day cleanup plan, require its derived identifier,
 # refresh all safety inputs, and delete only unchanged planned resources.
@@ -5550,7 +5663,8 @@ _maintenance-require-database stage:
         --filter="status=RUNNING" --limit=1 --format="value(name)" 2>/dev/null || echo "unknown")
     if [ "$DB_STATUS" != "RUNNABLE" ] || [ -n "$ACTIVE_OPERATION" ]; then
         echo "Error: Cloud SQL instance $DB_INSTANCE is not ready (state=$DB_STATUS active-operation=${ACTIVE_OPERATION:-none})." >&2
-        echo "Run 'just gcp maintenance-on {{stage}}' before this command." >&2
+        echo "Inspect the lifecycle with 'just gcp mode-status {{stage}}'." >&2
+        echo "If the stage is intentionally offline, use 'just gcp mode-maintenance {{stage}}'." >&2
         exit 1
     fi
 
@@ -5648,7 +5762,11 @@ _maintenance-assert-offline stage:
         revision_min=$(jq -r '.spec.template.metadata.annotations["autoscaling.knative.dev/minScale"] // "0"' <<< "$service_json")
         mcp_enabled=$(jq -r '[.spec.template.spec.containers[0].env[]? | select(.name == "VALIDIBOT_MCP_ENABLED") | .value][0] // "true"' <<< "$service_json")
         if [ "$ingress" != "internal" ] || [ "$service_min" != "0" ] || [ "$revision_min" != "0" ] || { [ "$expect_mcp_disabled" = "1" ] && [ "$mcp_enabled" != "false" ]; }; then
-            record_isolation_error "$service is not isolated (ingress=$ingress service-min=$service_min revision-min=$revision_min)."
+            if [ "$expect_mcp_disabled" = "1" ]; then
+                record_isolation_error "$service is not isolated (ingress=$ingress service-min=$service_min revision-min=$revision_min VALIDIBOT_MCP_ENABLED=$mcp_enabled)."
+            else
+                record_isolation_error "$service is not isolated (ingress=$ingress service-min=$service_min revision-min=$revision_min)."
+            fi
         fi
     }
     check_isolated_service "$WEB_SERVICE" 0 1
@@ -5677,7 +5795,7 @@ _maintenance-assert-offline stage:
     if [ "$PROVIDER_STATE" != "PAUSED" ] && [ "$PROVIDER_STATE" != "NOT_FOUND" ]; then
         record_isolation_error "provider queue is $PROVIDER_STATE, not PAUSED."
     fi
-    for job_base in ${APP_NAME}-clear-sessions ${APP_NAME}-cleanup-idempotency-keys ${APP_NAME}-cleanup-callback-receipts ${APP_NAME}-purge-expired-submissions ${APP_NAME}-purge-expired-outputs ${APP_NAME}-process-purge-retries ${APP_NAME}-cleanup-stuck-runs ${APP_NAME}-verify-validator-deployments ${APP_NAME}-send-periodic-emails ${APP_NAME}-enforce-audit-retention ${APP_NAME}-verify-license-document-hashes; do
+    for job_base in ${APP_NAME}-clear-sessions ${APP_NAME}-cleanup-idempotency-keys ${APP_NAME}-cleanup-callback-receipts ${APP_NAME}-purge-expired-submissions ${APP_NAME}-purge-expired-outputs ${APP_NAME}-process-purge-retries ${APP_NAME}-cleanup-stuck-runs ${APP_NAME}-verify-validator-deployments ${APP_NAME}-send-periodic-emails ${APP_NAME}-enforce-audit-retention; do
         job="${job_base}${JOB_SUFFIX}"
         state=$(gcloud scheduler jobs describe "$job" \
             --project {{gcp_project}} --location {{gcp_region}} \
@@ -5773,7 +5891,7 @@ _enforce-maintenance stage:
         record_maintenance_error "could not list validator Cloud Run services."
     fi
 
-    for job_base in ${APP_NAME}-clear-sessions ${APP_NAME}-cleanup-idempotency-keys ${APP_NAME}-cleanup-callback-receipts ${APP_NAME}-purge-expired-submissions ${APP_NAME}-purge-expired-outputs ${APP_NAME}-process-purge-retries ${APP_NAME}-cleanup-stuck-runs ${APP_NAME}-verify-validator-deployments ${APP_NAME}-send-periodic-emails ${APP_NAME}-enforce-audit-retention ${APP_NAME}-verify-license-document-hashes; do
+    for job_base in ${APP_NAME}-clear-sessions ${APP_NAME}-cleanup-idempotency-keys ${APP_NAME}-cleanup-callback-receipts ${APP_NAME}-purge-expired-submissions ${APP_NAME}-purge-expired-outputs ${APP_NAME}-process-purge-retries ${APP_NAME}-cleanup-stuck-runs ${APP_NAME}-verify-validator-deployments ${APP_NAME}-send-periodic-emails ${APP_NAME}-enforce-audit-retention; do
         job="${job_base}${JOB_SUFFIX}"
         if gcloud scheduler jobs describe "$job" --project {{gcp_project}} --location {{gcp_region}} &>/dev/null; then
             if ! gcloud scheduler jobs pause "$job" \
@@ -5853,53 +5971,110 @@ _maintenance-stop-database stage:
     echo "Error: Cloud SQL instance $DB_INSTANCE did not become STOPPED within the transition timeout." >&2
     exit 1
 
-# Put a stage into maintenance mode: isolate runtime and keep its database ready.
+# Lifecycle states are reconciled rather than toggled. Every successful public
+# transition verifies its requested target, while any error or interruption
+# restores maintenance isolation before returning the original failure status.
+
+# Reconcile a stage to MAINTENANCE: runtime isolated, work paused, database
+# RUNNABLE. Cloud SQL remains billable in this state for consecutive operator
+# tasks; use mode-parked when the stage will be idle for a longer period.
 [arg('stage', pattern='dev|staging|prod')]
-maintenance-on stage: _require-gcp-config
+mode-maintenance stage: _require-gcp-config
     #!/usr/bin/env bash
     set -euo pipefail
     if [ "{{stage}}" = "prod" ] && [ "${GCP_YES:-0}" != "1" ]; then
-        echo "WARNING: This will take PRODUCTION offline."
-        read -r -p "Type 'yes' to confirm: " REPLY
-        if [ "$REPLY" != "yes" ]; then echo "Cancelled."; exit 1; fi
+        echo "WARNING: This will take PRODUCTION offline while Cloud SQL remains running and billable."
+        read -r -p "Type 'maintenance' to confirm: " REPLY
+        if [ "$REPLY" != "maintenance" ]; then echo "Cancelled."; exit 1; fi
     fi
-    trap 'just gcp _enforce-maintenance {{stage}}' EXIT
+    cleanup() {
+        local status=$?
+        trap - EXIT INT TERM
+        if [ "$status" -ne 0 ]; then
+            if ! just gcp _enforce-maintenance {{stage}}; then
+                echo "Error: failed to restore maintenance isolation after the interrupted transition." >&2
+                exit 1
+            fi
+        fi
+        exit "$status"
+    }
+    trap cleanup EXIT INT TERM
     just gcp _enforce-maintenance {{stage}}
     just gcp _maintenance-start-database {{stage}}
-    trap - EXIT
+    MODE=$(just gcp _mode-current {{stage}})
+    if [ "$MODE" != "MAINTENANCE" ]; then
+        echo "Error: {{stage}} did not converge to MAINTENANCE (current mode: $MODE)." >&2
+        exit 1
+    fi
+    trap - EXIT INT TERM
     echo "{{stage}} is in MAINTENANCE: runtime isolated, work paused, database available."
+    echo "Cloud SQL is still running and billed; use 'just gcp mode-parked {{stage}}' when it can be stopped."
 
-# Park an already isolated stage by explicitly stopping its database.
+# Reconcile a stage to PARKED. This takes a live stage offline before stopping
+# Cloud SQL, so it is safe to use from LIVE, MAINTENANCE, PARKED, or a partial
+# transition.
 [arg('stage', pattern='dev|staging|prod')]
-maintenance-park stage: _require-gcp-config
+mode-parked stage: _require-gcp-config
     #!/usr/bin/env bash
     set -euo pipefail
     if [ "{{stage}}" = "prod" ] && [ "${GCP_YES:-0}" != "1" ]; then
-        echo "WARNING: This will stop the PRODUCTION database while keeping the runtime isolated."
+        echo "WARNING: This will take LIVE PRODUCTION offline, isolate runtime and work, and stop Cloud SQL."
         read -r -p "Type 'park' to confirm: " REPLY
         if [ "$REPLY" != "park" ]; then echo "Cancelled."; exit 1; fi
     fi
-    trap 'just gcp _enforce-maintenance {{stage}}' EXIT
+    cleanup() {
+        local status=$?
+        trap - EXIT INT TERM
+        if [ "$status" -ne 0 ]; then
+            if ! just gcp _enforce-maintenance {{stage}}; then
+                echo "Error: failed to restore maintenance isolation after the interrupted transition." >&2
+                exit 1
+            fi
+        fi
+        exit "$status"
+    }
+    trap cleanup EXIT INT TERM
     just gcp _enforce-maintenance {{stage}}
     just gcp _maintenance-stop-database {{stage}}
-    trap - EXIT
+    MODE=$(just gcp _mode-current {{stage}})
+    if [ "$MODE" != "PARKED" ]; then
+        echo "Error: {{stage}} did not converge to PARKED (current mode: $MODE)." >&2
+        exit 1
+    fi
+    trap - EXIT INT TERM
     echo "{{stage}} is PARKED: runtime isolated, work paused, database stopped."
 
-# Reconcile existing stage infrastructure while preserving maintenance mode.
+# Reconcile existing stage infrastructure while preserving MAINTENANCE.
 [arg('stage', pattern='dev|staging|prod')]
 init-stage-maintenance stage: _require-gcp-config
     #!/usr/bin/env bash
     set -euo pipefail
     just gcp _maintenance-assert-offline {{stage}}
-    trap 'just gcp _enforce-maintenance {{stage}}' EXIT
-    just gcp _maintenance-start-database {{stage}}
-    just gcp init-stage {{stage}}
+    cleanup() {
+        local status=$?
+        trap - EXIT INT TERM
+        if [ "$status" -ne 0 ]; then
+            if ! just gcp _enforce-maintenance {{stage}}; then
+                echo "Error: failed to restore maintenance isolation after init-stage failed." >&2
+                exit 1
+            fi
+        fi
+        exit "$status"
+    }
+    trap cleanup EXIT INT TERM
+    GCP_YES=1 just gcp mode-maintenance {{stage}}
+    GCP_INIT_STAGE_MAINTENANCE=1 just gcp init-stage {{stage}}
     just gcp _enforce-maintenance {{stage}}
-    trap - EXIT
+    MODE=$(just gcp _mode-current {{stage}})
+    if [ "$MODE" != "MAINTENANCE" ]; then
+        echo "Error: init-stage did not leave {{stage}} in MAINTENANCE (current mode: $MODE)." >&2
+        exit 1
+    fi
+    trap - EXIT INT TERM
 
 # Build and deploy the newest app revision without bringing the stage online.
-# Cloud SQL stays available for maintenance work; an EXIT trap restores runtime
-# isolation even if a build, migration, or deployment fails.
+# Cloud SQL stays available for maintenance work; a failed or interrupted
+# command leaves runtime and asynchronous work isolated.
 [arg('stage', pattern='dev|staging|prod')]
 deploy-maintenance stage: _require-gcp-config
     #!/usr/bin/env bash
@@ -5910,44 +6085,96 @@ deploy-maintenance stage: _require-gcp-config
         if [ "$REPLY" != "prod" ]; then echo "Cancelled."; exit 1; fi
     fi
     just gcp _maintenance-assert-offline {{stage}}
-    trap 'just gcp _enforce-maintenance {{stage}}' EXIT
-    just gcp _enforce-maintenance {{stage}}
+    cleanup() {
+        local status=$?
+        trap - EXIT INT TERM
+        if [ "$status" -ne 0 ]; then
+            if ! just gcp _enforce-maintenance {{stage}}; then
+                echo "Error: failed to restore maintenance isolation after the interrupted deploy." >&2
+                exit 1
+            fi
+        fi
+        exit "$status"
+    }
+    trap cleanup EXIT INT TERM
+    GCP_YES=1 just gcp mode-maintenance {{stage}}
     just gcp build
     just gcp push
-    just gcp _maintenance-start-database {{stage}}
     just gcp _migrate {{stage}}
     GCP_DEPLOY_MAINTENANCE=1 just gcp _deploy-web {{stage}}
     GCP_DEPLOY_MAINTENANCE=1 just gcp _deploy-worker {{stage}}
     GCP_DEPLOY_MAINTENANCE=1 just gcp scheduler-setup {{stage}}
     GCP_DEPLOY_MAINTENANCE=1 just gcp _maybe-deploy-mcp {{stage}}
     just gcp _enforce-maintenance {{stage}}
-    trap - EXIT
-    echo "Latest revision deployed to {{stage}}; maintenance mode remains on."
+    MODE=$(just gcp _mode-current {{stage}})
+    if [ "$MODE" != "MAINTENANCE" ]; then
+        echo "Error: maintenance deploy did not leave {{stage}} in MAINTENANCE (current mode: $MODE)." >&2
+        exit 1
+    fi
+    trap - EXIT INT TERM
+    echo "Latest revision deployed to {{stage}}; MAINTENANCE remains active."
 
-# Run a Django management command during maintenance without opening traffic.
+# Run a Django management command during MAINTENANCE without opening traffic.
 [arg('stage', pattern='dev|staging|prod')]
 maintenance-management-cmd stage command: _require-gcp-config
     #!/usr/bin/env bash
     set -euo pipefail
     just gcp _maintenance-assert-offline {{stage}}
-    trap 'just gcp _enforce-maintenance {{stage}}' EXIT
-    just gcp _maintenance-start-database {{stage}}
+    cleanup() {
+        local status=$?
+        trap - EXIT INT TERM
+        if [ "$status" -ne 0 ]; then
+            if ! just gcp _enforce-maintenance {{stage}}; then
+                echo "Error: failed to restore maintenance isolation after the management command." >&2
+                exit 1
+            fi
+        fi
+        exit "$status"
+    }
+    trap cleanup EXIT INT TERM
+    GCP_YES=1 just gcp mode-maintenance {{stage}}
     just gcp management-cmd {{stage}} "{{command}}"
     just gcp _enforce-maintenance {{stage}}
-    trap - EXIT
+    MODE=$(just gcp _mode-current {{stage}})
+    if [ "$MODE" != "MAINTENANCE" ]; then
+        echo "Error: management command did not leave {{stage}} in MAINTENANCE (current mode: $MODE)." >&2
+        exit 1
+    fi
+    trap - EXIT INT TERM
 
-# Bring a stage online. Database readiness is proven before any service,
-# queue, scheduler, or public ingress is restored.
+# Reconcile a stage to LIVE. Database readiness, runtime capacity, queues, and
+# every managed scheduler job are restored before either public ingress opens.
 [arg('stage', pattern='dev|staging|prod')]
-maintenance-off stage: _require-gcp-config
+mode-live stage: _require-gcp-config
     #!/usr/bin/env bash
     set -euo pipefail
     APP_NAME="{{app_name}}"
+    CURRENT_MODE=$(just gcp _mode-current {{stage}})
+    if [ "$CURRENT_MODE" = "LIVE" ]; then
+        echo "{{stage}} is already LIVE."
+        exit 0
+    fi
     if [ "{{stage}}" = "prod" ] && [ "${GCP_YES:-0}" != "1" ]; then
         echo "WARNING: This will bring PRODUCTION online."
-        read -r -p "Type 'prod' to confirm: " REPLY
-        if [ "$REPLY" != "prod" ]; then echo "Cancelled."; exit 1; fi
+        read -r -p "Type 'live' to confirm: " REPLY
+        if [ "$REPLY" != "live" ]; then echo "Cancelled."; exit 1; fi
     fi
+    cleanup() {
+        local status=$?
+        trap - EXIT INT TERM
+        if [ "$status" -ne 0 ]; then
+            if ! just gcp _enforce-maintenance {{stage}}; then
+                echo "Error: failed to restore maintenance isolation after the interrupted LIVE transition." >&2
+                exit 1
+            fi
+        fi
+        exit "$status"
+    }
+    trap cleanup EXIT INT TERM
+    # Begin every non-LIVE reconciliation from the known-safe isolated state.
+    # This repairs partially opened runtime components before queues, capacity,
+    # schedulers, and public ingress are restored in their strict order.
+    just gcp _enforce-maintenance {{stage}}
     if [ "{{stage}}" = "prod" ]; then
         WEB_SERVICE="${APP_NAME}-web"
         WORKER_SERVICE="${APP_NAME}-worker"
@@ -5983,8 +6210,7 @@ maintenance-off stage: _require-gcp-config
     if gcloud compute network-endpoint-groups describe "$WEB_NEG" --region={{gcp_region}} --project={{gcp_project}} &>/dev/null; then WEB_INGRESS="internal-and-cloud-load-balancing"; else WEB_INGRESS="all"; fi
     if gcloud compute network-endpoint-groups describe "$MCP_NEG" --region={{gcp_region}} --project={{gcp_project}} &>/dev/null; then MCP_INGRESS="internal-and-cloud-load-balancing"; else MCP_INGRESS="all"; fi
 
-    # Restore desired capacity while ingress remains closed. Public traffic is
-    # the final transition only after every queue and scheduler is ready.
+    # Restore capacity while all externally reachable ingress remains closed.
     gcloud run services update "$WEB_SERVICE" \
         --region {{gcp_region}} --project {{gcp_project}} \
         --ingress internal --min="$WEB_MIN" --quiet
@@ -6014,17 +6240,30 @@ maintenance-off stage: _require-gcp-config
             --region {{gcp_region}} --project {{gcp_project}} \
             --ingress internal --min="$desired" --quiet
     done <<< "$SERVICES"
+
+    # Reconcile the managed jobs in a paused state before any scheduler can
+    # dispatch. The strict loop below verifies every expected job before
+    # resuming it.
+    GCP_DEPLOY_MAINTENANCE=1 just gcp scheduler-setup {{stage}}
     gcloud tasks queues resume "$QUEUE_NAME" \
         --location {{gcp_region}} --project {{gcp_project}} --quiet
-    gcloud tasks queues resume "$PROVIDER_QUEUE_NAME" \
-        --location {{gcp_region}} --project {{gcp_project}} --quiet
-    for job_base in ${APP_NAME}-clear-sessions ${APP_NAME}-cleanup-idempotency-keys ${APP_NAME}-cleanup-callback-receipts ${APP_NAME}-purge-expired-submissions ${APP_NAME}-purge-expired-outputs ${APP_NAME}-process-purge-retries ${APP_NAME}-cleanup-stuck-runs ${APP_NAME}-verify-validator-deployments ${APP_NAME}-send-periodic-emails ${APP_NAME}-enforce-audit-retention ${APP_NAME}-verify-license-document-hashes; do
+    if gcloud tasks queues describe "$PROVIDER_QUEUE_NAME" \
+        --location {{gcp_region}} --project {{gcp_project}} &>/dev/null; then
+        gcloud tasks queues resume "$PROVIDER_QUEUE_NAME" \
+            --location {{gcp_region}} --project {{gcp_project}} --quiet
+    fi
+    for job_base in ${APP_NAME}-clear-sessions ${APP_NAME}-cleanup-idempotency-keys ${APP_NAME}-cleanup-callback-receipts ${APP_NAME}-purge-expired-submissions ${APP_NAME}-purge-expired-outputs ${APP_NAME}-process-purge-retries ${APP_NAME}-cleanup-stuck-runs ${APP_NAME}-verify-validator-deployments ${APP_NAME}-send-periodic-emails ${APP_NAME}-enforce-audit-retention; do
         job="${job_base}${JOB_SUFFIX}"
-        if gcloud scheduler jobs describe "$job" --project {{gcp_project}} --location {{gcp_region}} &>/dev/null; then
-            gcloud scheduler jobs resume "$job" \
-                --project {{gcp_project}} --location {{gcp_region}} --quiet
+        if ! gcloud scheduler jobs describe "$job" --project {{gcp_project}} --location {{gcp_region}} &>/dev/null; then
+            echo "Error: required managed scheduler job $job is missing." >&2
+            exit 1
         fi
+        gcloud scheduler jobs resume "$job" \
+            --project {{gcp_project}} --location {{gcp_region}} --quiet
     done
+
+    # Public ingress is deliberately the final mutation after all dependent
+    # runtime work has been restored.
     gcloud run services update "$WEB_SERVICE" \
         --region {{gcp_region}} --project {{gcp_project}} \
         --ingress "$WEB_INGRESS" --min="$WEB_MIN" --quiet
@@ -6034,11 +6273,18 @@ maintenance-off stage: _require-gcp-config
             --ingress "$MCP_INGRESS" --min=0 \
             --update-env-vars "VALIDIBOT_MCP_ENABLED=$MCP_ENABLED" --quiet
     fi
-    echo "{{stage}} is online: database ready, service capacity restored, work resumed."
+    MODE=$(just gcp _mode-current {{stage}})
+    if [ "$MODE" != "LIVE" ]; then
+        echo "Error: {{stage}} did not converge to LIVE (current mode: $MODE)." >&2
+        exit 1
+    fi
+    trap - EXIT INT TERM
+    echo "{{stage}} is LIVE: database ready, runtime restored, queues and schedulers enabled."
 
-# Report whether a stage is online, in maintenance, parked, or mid-transition.
+# Report the reconciled lifecycle mode. LIVE requires every managed scheduler
+# job to be exactly ENABLED; a missing, paused, or unknown job is not LIVE.
 [arg('stage', pattern='dev|staging|prod')]
-maintenance-status stage: _require-gcp-config
+mode-status stage: _require-gcp-config
     #!/usr/bin/env bash
     set -euo pipefail
     APP_NAME="{{app_name}}"
@@ -6073,7 +6319,8 @@ maintenance-status stage: _require-gcp-config
     WEB_INGRESS="unknown"
     WEB_SERVICE_MIN="unknown"
     WEB_REVISION_MIN="unknown"
-    RUNTIME_ISSUES=0
+    RUNTIME_ISOLATION_ISSUES=0
+    LIVE_RUNTIME_ISSUES=0
     RUNTIME_INSPECTION_ERRORS=0
     echo "Stage status for {{stage}}"
     check_service() {
@@ -6085,7 +6332,8 @@ maintenance-status stage: _require-gcp-config
             --region {{gcp_region}} --project {{gcp_project}} --format=json 2>/dev/null); then
             if [ "$required" = "1" ]; then
                 echo "  Runtime:       $service could not be inspected"
-                RUNTIME_ISSUES=$((RUNTIME_ISSUES + 1))
+                RUNTIME_ISOLATION_ISSUES=$((RUNTIME_ISOLATION_ISSUES + 1))
+                LIVE_RUNTIME_ISSUES=$((LIVE_RUNTIME_ISSUES + 1))
                 RUNTIME_INSPECTION_ERRORS=$((RUNTIME_INSPECTION_ERRORS + 1))
             else
                 echo "  Runtime:       $service not present"
@@ -6107,7 +6355,12 @@ maintenance-status stage: _require-gcp-config
             echo "  Runtime:       $service ingress=$ingress service-min=$service_min revision-min=$revision_min"
         fi
         if [ "$ingress" != "internal" ] || [ "$service_min" != "0" ] || [ "$revision_min" != "0" ] || { [ "$expect_mcp_disabled" = "1" ] && [ "$mcp_enabled" != "false" ]; }; then
-            RUNTIME_ISSUES=$((RUNTIME_ISSUES + 1))
+            RUNTIME_ISOLATION_ISSUES=$((RUNTIME_ISOLATION_ISSUES + 1))
+        fi
+        if [ "$service" = "$WEB_SERVICE" ] || [ "$service" = "$MCP_SERVICE" ]; then
+            if [ "$ingress" != "all" ] && [ "$ingress" != "internal-and-cloud-load-balancing" ]; then
+                LIVE_RUNTIME_ISSUES=$((LIVE_RUNTIME_ISSUES + 1))
+            fi
         fi
     }
     check_service "$WEB_SERVICE" 0 1
@@ -6123,20 +6376,27 @@ maintenance-status stage: _require-gcp-config
         done <<< "$SERVICES"
     else
         echo "  Runtime:       validator services could not be listed"
-        RUNTIME_ISSUES=$((RUNTIME_ISSUES + 1))
+        RUNTIME_ISOLATION_ISSUES=$((RUNTIME_ISOLATION_ISSUES + 1))
+        LIVE_RUNTIME_ISSUES=$((LIVE_RUNTIME_ISSUES + 1))
         RUNTIME_INSPECTION_ERRORS=$((RUNTIME_INSPECTION_ERRORS + 1))
     fi
-    SCHEDULER_ACTIVE=0
+    SCHEDULER_EXPECTED=10
+    SCHEDULER_ENABLED=0
     SCHEDULER_PAUSED=0
-    for job_base in ${APP_NAME}-clear-sessions ${APP_NAME}-cleanup-idempotency-keys ${APP_NAME}-cleanup-callback-receipts ${APP_NAME}-purge-expired-submissions ${APP_NAME}-purge-expired-outputs ${APP_NAME}-process-purge-retries ${APP_NAME}-cleanup-stuck-runs ${APP_NAME}-verify-validator-deployments ${APP_NAME}-send-periodic-emails ${APP_NAME}-enforce-audit-retention ${APP_NAME}-verify-license-document-hashes; do
+    SCHEDULER_OTHER=0
+    SCHEDULER_MISSING=0
+    for job_base in ${APP_NAME}-clear-sessions ${APP_NAME}-cleanup-idempotency-keys ${APP_NAME}-cleanup-callback-receipts ${APP_NAME}-purge-expired-submissions ${APP_NAME}-purge-expired-outputs ${APP_NAME}-process-purge-retries ${APP_NAME}-cleanup-stuck-runs ${APP_NAME}-verify-validator-deployments ${APP_NAME}-send-periodic-emails ${APP_NAME}-enforce-audit-retention; do
         job="${job_base}${JOB_SUFFIX}"
-        state=$(gcloud scheduler jobs describe "$job" \
+        if state=$(gcloud scheduler jobs describe "$job" \
             --project {{gcp_project}} --location {{gcp_region}} \
-            --format="value(state)" 2>/dev/null || echo "NOT_FOUND")
-        if [ "$state" = "PAUSED" ]; then
-            SCHEDULER_PAUSED=$((SCHEDULER_PAUSED + 1))
-        elif [ "$state" != "NOT_FOUND" ]; then
-            SCHEDULER_ACTIVE=$((SCHEDULER_ACTIVE + 1))
+            --format="value(state)" 2>/dev/null); then
+            case "$state" in
+                ENABLED) SCHEDULER_ENABLED=$((SCHEDULER_ENABLED + 1)) ;;
+                PAUSED) SCHEDULER_PAUSED=$((SCHEDULER_PAUSED + 1)) ;;
+                *) SCHEDULER_OTHER=$((SCHEDULER_OTHER + 1)) ;;
+            esac
+        else
+            SCHEDULER_MISSING=$((SCHEDULER_MISSING + 1))
         fi
     done
     echo "  Web ingress:   $WEB_INGRESS"
@@ -6145,20 +6405,19 @@ maintenance-status stage: _require-gcp-config
     echo "  DB operation:  ${DB_ACTIVE_OPERATION:-none}"
     echo "  Main queue:    $QUEUE_STATUS"
     echo "  Provider queue: $PROVIDER_STATUS"
-    echo "  Active schedulers: $SCHEDULER_ACTIVE"
-    echo "  Paused schedulers: $SCHEDULER_PAUSED"
+    echo "  Scheduler jobs: enabled=$SCHEDULER_ENABLED paused=$SCHEDULER_PAUSED other=$SCHEDULER_OTHER missing=$SCHEDULER_MISSING expected=$SCHEDULER_EXPECTED"
     RUNTIME_ISOLATED=0
-    if [ "$WEB_INGRESS" = "internal" ] && [ "$WEB_SERVICE_MIN" = "0" ] && [ "$WEB_REVISION_MIN" = "0" ] && [ "$QUEUE_STATUS" = "PAUSED" ] && [ "$RUNTIME_ISSUES" = "0" ] && [ "$SCHEDULER_ACTIVE" = "0" ] && { [ "$PROVIDER_STATUS" = "PAUSED" ] || [ "$PROVIDER_STATUS" = "NOT_FOUND" ]; }; then
+    if [ "$WEB_INGRESS" = "internal" ] && [ "$WEB_SERVICE_MIN" = "0" ] && [ "$WEB_REVISION_MIN" = "0" ] && [ "$QUEUE_STATUS" = "PAUSED" ] && [ "$RUNTIME_ISOLATION_ISSUES" = "0" ] && [ "$SCHEDULER_ENABLED" = "0" ] && [ "$SCHEDULER_OTHER" = "0" ] && { [ "$PROVIDER_STATUS" = "PAUSED" ] || [ "$PROVIDER_STATUS" = "NOT_FOUND" ]; }; then
         RUNTIME_ISOLATED=1
     fi
     if [ "$RUNTIME_ISOLATED" = "1" ] && [ "$DB_STATUS" = "RUNNABLE" ] && [ -z "$DB_ACTIVE_OPERATION" ]; then
-        echo "  Overall:       MAINTENANCE (isolated, database available)"
+        echo "  Overall:       MAINTENANCE"
     elif [ "$RUNTIME_ISOLATED" = "1" ] && [ "$DB_STATUS" = "STOPPED" ] && [ -z "$DB_ACTIVE_OPERATION" ]; then
-        echo "  Overall:       PARKED (isolated, database stopped)"
-    elif [ "$RUNTIME_INSPECTION_ERRORS" = "0" ] && [ "$DB_STATUS" = "RUNNABLE" ] && [ -z "$DB_ACTIVE_OPERATION" ] && [ "$WEB_INGRESS" != "internal" ] && [ "$WEB_INGRESS" != "unknown" ] && [ "$QUEUE_STATUS" = "RUNNING" ] && [ "$SCHEDULER_PAUSED" = "0" ] && { [ "$PROVIDER_STATUS" = "RUNNING" ] || [ "$PROVIDER_STATUS" = "NOT_FOUND" ]; }; then
-        echo "  Overall:       ONLINE"
+        echo "  Overall:       PARKED"
+    elif [ "$RUNTIME_INSPECTION_ERRORS" = "0" ] && [ "$LIVE_RUNTIME_ISSUES" = "0" ] && [ "$DB_STATUS" = "RUNNABLE" ] && [ -z "$DB_ACTIVE_OPERATION" ] && [ "$QUEUE_STATUS" = "RUNNING" ] && [ "$SCHEDULER_ENABLED" = "$SCHEDULER_EXPECTED" ] && [ "$SCHEDULER_PAUSED" = "0" ] && [ "$SCHEDULER_OTHER" = "0" ] && [ "$SCHEDULER_MISSING" = "0" ] && { [ "$PROVIDER_STATUS" = "RUNNING" ] || [ "$PROVIDER_STATUS" = "NOT_FOUND" ]; }; then
+        echo "  Overall:       LIVE"
     else
-        echo "  Overall:       PARTIALLY TRANSITIONED"
+        echo "  Overall:       PARTIALLY_TRANSITIONED"
     fi
     echo ""
 
@@ -7490,7 +7749,7 @@ backup stage: _require-gcp-config
 #     drain).  Cloud SQL import takes the DB offline briefly; the
 #     deployed Cloud Run services queue requests during that
 #     window.  Future iteration may add explicit
-#     ``maintenance-on`` / ``maintenance-off`` wrapping.
+#     ``mode-maintenance`` / ``mode-live`` wrapping.
 
 # Restore from a backup (DB import + media rsync + manifest verification).
 [arg('stage', pattern='dev|staging|prod')]

--- a/just/mcp/mod.just
+++ b/just/mcp/mod.just
@@ -524,7 +524,7 @@ deploy stage: _require-gcp-config
         # A maintenance revision must become ready while the Django issuer/API
         # is intentionally internal and Cloud SQL is about to stop. Disabling
         # MCP skips its startup license request and makes every tool return 503;
-        # maintenance-off restores the configured value after web is online.
+        # mode-live restores the configured value after web is online.
         MCP_ENABLED=false
     fi
     SET_ENV_VARS="VALIDIBOT_API_BASE_URL=${API_BASE_URL},VALIDIBOT_MCP_BASE_URL=${MCP_BASE_URL},VALIDIBOT_MCP_ENABLED=${MCP_ENABLED}"

--- a/mcp/tests/test_license_check.py
+++ b/mcp/tests/test_license_check.py
@@ -16,7 +16,7 @@ These tests cover the three outcomes that matter operationally:
 
 Maintenance is the deliberate exception: a disabled, internal revision skips
 the API request so Cloud Run can stage it while Django is offline. MCP's global
-gate returns 503 in that state, and maintenance-off re-enables it so the next
+gate returns 503 in that state, and mode-live re-enables it so the next
 revision performs the normal license check.
 """
 

--- a/tests/test_self_hosted_kit.py
+++ b/tests/test_self_hosted_kit.py
@@ -854,14 +854,15 @@ class GcpOperatorRecipeInvariantTests(SimpleTestCase):
         assert "spec.template.spec.template.spec.containers[0].image" in block
         assert "spec.template.template.containers[0].image" not in block
 
-    def test_health_is_load_balancer_aware_and_maintenance_is_strict(self):
-        """Health uses the public LB while maintenance checks the offline state.
+    def test_health_and_status_cover_every_stage_lifecycle_state(self):
+        """Health uses the public LB while status classifies lifecycle state.
 
         The direct run.app URL is deliberately unavailable under
         ``internal-and-cloud-load-balancing``. Health checks therefore use the
-        configured public ``SITE_URL`` and fail on non-2xx responses. A stage
-        only counts as safely offline when ingress, minimum capacity, database,
-        and queues all agree; checking ingress alone hides billable instances.
+        configured public ``SITE_URL`` and fail on non-2xx responses. Status
+        distinguishes online, runtime-isolated maintenance, fully parked, and
+        partially transitioned states so an incomplete inspection cannot be
+        mistaken for a safe or ready deployment.
         """
         health_block = self._block_between(
             "health-check stage:",
@@ -878,21 +879,27 @@ class GcpOperatorRecipeInvariantTests(SimpleTestCase):
         assert "WEB_SERVICE_MIN" in maintenance_block
         assert "WEB_REVISION_MIN" in maintenance_block
         assert "DB_ACTIVE_OPERATION" in maintenance_block
+        assert 'DB_STATUS" = "RUNNABLE"' in maintenance_block
         assert 'DB_STATUS" = "STOPPED"' in maintenance_block
         assert '-z "$DB_ACTIVE_OPERATION"' in maintenance_block
         assert 'QUEUE_STATUS" = "PAUSED"' in maintenance_block
-        assert "MAINTENANCE (safely offline)" in maintenance_block
+        assert "RUNTIME_INSPECTION_ERRORS" in maintenance_block
+        assert "MAINTENANCE (isolated, database available)" in maintenance_block
+        assert "PARKED (isolated, database stopped)" in maintenance_block
+        assert "ONLINE" in maintenance_block
+        assert "PARTIALLY TRANSITIONED" in maintenance_block
 
     def test_maintenance_enforcement_scales_every_runtime_surface_to_zero(self):
-        """Maintenance must stop warm instances as well as block public traffic.
+        """Maintenance isolates runtime and work without changing Cloud SQL.
 
         Web, worker, optional MCP, and validator Services can each retain paid
         minimum capacity. Central enforcement prevents a partial shutdown from
-        looking safe while one of those surfaces remains warm.
+        looking safe while one of those surfaces remains warm, while keeping
+        the database available for consecutive operator tasks.
         """
         block = self._block_between(
             "_enforce-maintenance stage:",
-            "# Put a stage into maintenance mode",
+            "_maintenance-stop-database stage:",
         )
 
         assert "--ingress internal --min=0" in block
@@ -904,13 +911,51 @@ class GcpOperatorRecipeInvariantTests(SimpleTestCase):
         assert "VALIDIBOT_MCP_ENABLED=false" in block
         assert 'queues pause "$QUEUE_NAME"' in block
         assert 'queues pause "$PROVIDER_QUEUE_NAME"' in block
+        assert "--activation-policy NEVER" not in block
+        assert "database state unchanged" in block
+        assert "MAINTENANCE_ERRORS" in block
+        assert "completed all possible safeguards" in block
+
+    def test_maintenance_park_is_the_only_explicit_database_stop_path(self):
+        """Parking, and only parking, explicitly stops an isolated database.
+
+        Keeping the SQL stop in one helper prevents deployments, management
+        commands, and validator setup from repeatedly stopping and restarting
+        Cloud SQL during a single maintenance session.
+        """
+        block = self._block_between(
+            "_maintenance-stop-database stage:",
+            "# Put a stage into maintenance mode",
+        )
+
+        assert "_maintenance-assert-offline" in block
         assert "--activation-policy NEVER" in block
         assert "--quiet --async" in block
         assert "another operation was already in progress" in block
         assert "GCP_SQL_TRANSITION_TIMEOUT_SECONDS" in block
         assert "sql operations list" in block
-        assert "MAINTENANCE_ERRORS" in block
-        assert "completed all possible safeguards" in block
+        assert 'DB_STATUS" = "STOPPED"' in block
+        assert '-z "$ACTIVE_OPERATION"' in block
+        assert self._gcp_mod_text().count("--activation-policy NEVER") == 1
+
+    def test_maintenance_on_isolates_runtime_then_starts_database(self):
+        """Entering maintenance leaves an isolated stage ready for DB work.
+
+        Runtime isolation must happen before Cloud SQL is made available. The
+        fail-closed trap restores isolation if the start fails, but it never
+        parks the database implicitly.
+        """
+        block = self._block_between(
+            "maintenance-on stage:",
+            "# Park an already isolated stage",
+        )
+
+        assert block.index("_enforce-maintenance") < block.index(
+            "_maintenance-start-database"
+        )
+        assert "trap 'just gcp _enforce-maintenance" in block
+        assert "_maintenance-stop-database" not in block
+        assert "runtime isolated, work paused, database available" in block
 
     def test_maintenance_database_start_polls_provider_state_asynchronously(self):
         """A slow Cloud SQL control-plane operation must not defeat cleanup.
@@ -935,11 +980,12 @@ class GcpOperatorRecipeInvariantTests(SimpleTestCase):
         assert '-z "$ACTIVE_OPERATION"' in block
 
     def test_maintenance_deploy_restores_offline_state_on_every_exit(self):
-        """An offline deployment must fail closed if any intermediate step fails.
+        """A maintenance deploy must fail closed if an intermediate step fails.
 
-        Migrations require Cloud SQL briefly, but traffic and task dispatch must
-        remain disabled. The EXIT trap is the recovery guarantee for build,
-        migration, web, worker, scheduler, and MCP failures.
+        Cloud SQL remains available throughout the maintenance session while
+        traffic and task dispatch stay disabled. The EXIT trap is the recovery
+        guarantee for build, migration, web, worker, scheduler, and MCP
+        failures, and must not implicitly park the database.
         """
         block = self._block_between(
             "deploy-maintenance stage:",
@@ -949,10 +995,34 @@ class GcpOperatorRecipeInvariantTests(SimpleTestCase):
         assert "_maintenance-assert-offline" in block
         assert "trap 'just gcp _enforce-maintenance" in block
         assert "_maintenance-start-database" in block
+        assert "_maintenance-stop-database" not in block
         assert "_migrate" in block
         maintenance_safe_child_steps = 4
         assert block.count("GCP_DEPLOY_MAINTENANCE=1") == maintenance_safe_child_steps
         assert "trap - EXIT" in block
+
+    def test_validator_database_commands_fail_fast_and_setup_enters_maintenance(self):
+        """Validator reconciliation must not depend on accidental SQL starts.
+
+        Read operations reject a stopped or transitioning database with a
+        concrete recovery command. First-time setup confirms its target before
+        entering maintenance, then performs its database-backed status check.
+        """
+        status_block = self._block_between(
+            "_validator-status-json stage output:",
+            "# Retain the exact accepted release record",
+        )
+        setup_block = self._block_between(
+            "validator-setup stage:",
+            "# Reconcile one backend",
+        )
+
+        assert "_maintenance-require-database" in status_block
+        assert "Type the GCP project ID to continue" in setup_block
+        assert setup_block.index("maintenance-on") < setup_block.index(
+            "_validator-status-json"
+        )
+        assert "_enforce-maintenance" in setup_block
 
     def test_maintenance_off_waits_for_database_before_resuming_work(self):
         """No traffic or queued work may resume against a starting database.
@@ -963,7 +1033,7 @@ class GcpOperatorRecipeInvariantTests(SimpleTestCase):
         """
         block = self._block_between(
             "maintenance-off stage:",
-            "# Report the signals that define maintenance mode",
+            "# Report whether a stage is online",
         )
 
         ready = block.index("_maintenance-start-database")

--- a/tests/test_self_hosted_kit.py
+++ b/tests/test_self_hosted_kit.py
@@ -54,6 +54,7 @@ ENVS_EXAMPLE_ROOT = REPO_ROOT / ".envs.example" / ".production" / ".self-hosted"
 DOCS_ROOT = REPO_ROOT / "docs" / "operations" / "self-hosting"
 GCP_SERVICE_ACCOUNT_ID_MAX_LENGTH = 30
 EXPECTED_RELEASE_VERIFICATION_CALL_COUNT = 2
+EXPECTED_LIVE_GUARDED_DEPLOYMENTS = 3
 
 # The two host-prep helper scripts the kit ships. Only these two
 # remain as scripts because they have to run *before* ``just`` is
@@ -860,7 +861,7 @@ class GcpOperatorRecipeInvariantTests(SimpleTestCase):
         The direct run.app URL is deliberately unavailable under
         ``internal-and-cloud-load-balancing``. Health checks therefore use the
         configured public ``SITE_URL`` and fail on non-2xx responses. Status
-        distinguishes online, runtime-isolated maintenance, fully parked, and
+        distinguishes LIVE, runtime-isolated maintenance, fully parked, and
         partially transitioned states so an incomplete inspection cannot be
         mistaken for a safe or ready deployment.
         """
@@ -868,26 +869,170 @@ class GcpOperatorRecipeInvariantTests(SimpleTestCase):
             "health-check stage:",
             "# Management Commands",
         )
-        maintenance_block = self._block_between(
-            "maintenance-status stage:",
+        status_block = self._block_between(
+            "mode-status stage:",
             "# Load Balancer & DNS",
         )
 
         assert "DJANGO_ENV_FILE" in health_block
         assert "SITE_URL" in health_block
         assert "curl --fail" in health_block
-        assert "WEB_SERVICE_MIN" in maintenance_block
-        assert "WEB_REVISION_MIN" in maintenance_block
-        assert "DB_ACTIVE_OPERATION" in maintenance_block
-        assert 'DB_STATUS" = "RUNNABLE"' in maintenance_block
-        assert 'DB_STATUS" = "STOPPED"' in maintenance_block
-        assert '-z "$DB_ACTIVE_OPERATION"' in maintenance_block
-        assert 'QUEUE_STATUS" = "PAUSED"' in maintenance_block
-        assert "RUNTIME_INSPECTION_ERRORS" in maintenance_block
-        assert "MAINTENANCE (isolated, database available)" in maintenance_block
-        assert "PARKED (isolated, database stopped)" in maintenance_block
-        assert "ONLINE" in maintenance_block
-        assert "PARTIALLY TRANSITIONED" in maintenance_block
+        assert "WEB_SERVICE_MIN" in status_block
+        assert "WEB_REVISION_MIN" in status_block
+        assert "DB_ACTIVE_OPERATION" in status_block
+        assert 'DB_STATUS" = "RUNNABLE"' in status_block
+        assert 'DB_STATUS" = "STOPPED"' in status_block
+        assert '-z "$DB_ACTIVE_OPERATION"' in status_block
+        assert 'QUEUE_STATUS" = "PAUSED"' in status_block
+        assert "RUNTIME_INSPECTION_ERRORS" in status_block
+        assert "SCHEDULER_EXPECTED=10" in status_block
+        assert "ENABLED)" in status_block
+        assert 'SCHEDULER_ENABLED" = "$SCHEDULER_EXPECTED"' in status_block
+        assert "Overall:       LIVE" in status_block
+        assert "Overall:       MAINTENANCE" in status_block
+        assert "Overall:       PARKED" in status_block
+        assert "PARTIALLY_TRANSITIONED" in status_block
+
+    def test_gcp_lifecycle_exposes_only_the_explicit_mode_commands(self):
+        """Operators need four unambiguous commands for lifecycle control.
+
+        The old maintenance verbs conflated runtime isolation with Cloud SQL
+        parking. Keeping only the explicit status, maintenance, parked, and
+        live commands prevents a future recipe from silently reintroducing the
+        database-only interpretation of maintenance.
+        """
+        text = self._gcp_mod_text()
+
+        for header in (
+            "mode-status stage:",
+            "mode-maintenance stage:",
+            "mode-parked stage:",
+            "mode-live stage:",
+        ):
+            assert header in text
+        for legacy_header in (
+            "maintenance-status stage:",
+            "maintenance-on stage:",
+            "maintenance-park stage:",
+            "maintenance-off stage:",
+        ):
+            assert legacy_header not in text
+
+    def test_live_guard_requires_reconciled_runtime_not_only_cloud_sql(self):
+        """Ordinary deploys must reject an isolated but RUNNABLE database.
+
+        MAINTENANCE intentionally keeps Cloud SQL online, so a database-only
+        check would let an ordinary deploy expose queues or ingress halfway
+        through an operator task. The guard must consume the complete mode
+        classifier and every ordinary deployment path must use it.
+        """
+        guard = self._block_between(
+            "_mode-require-live stage:",
+            "# Print the reconciled lifecycle mode",
+        )
+        text = self._gcp_mod_text()
+
+        assert "_mode-current" in guard
+        assert "sql instances describe" not in guard
+        assert (
+            text.count("(_mode-require-live stage)")
+            == EXPECTED_LIVE_GUARDED_DEPLOYMENTS
+        )
+
+    def test_init_stage_requires_live_unless_maintenance_wrapper_opted_in(self):
+        """Existing infrastructure must not be reconciled through isolation.
+
+        `init-stage` can mutate a deployed stage, so it accepts an existing
+        database only after proving complete LIVE state. The dedicated wrapper
+        explicitly opts in after it has installed its own fail-closed cleanup.
+        """
+        text = self._gcp_mod_text()
+        start = text.index("init-stage stage:")
+        init_block = text[start : start + 7000]
+        wrapper = self._block_between(
+            "init-stage-maintenance stage:",
+            "# Build and deploy the newest app revision",
+        )
+
+        assert 'GCP_INIT_STAGE_MAINTENANCE:-0}" != "1"' in init_block
+        assert "CURRENT_MODE=$(just gcp _mode-current {{stage}})" in init_block
+        assert "existing stage {{stage}} is not LIVE" in init_block
+        assert "GCP_INIT_STAGE_MAINTENANCE=1 just gcp init-stage {{stage}}" in wrapper
+
+    def test_mode_transitions_trap_failures_and_verify_their_target(self):
+        """Lifecycle mutations must be interrupt-safe and fail closed.
+
+        An EXIT-only cleanup misses common Ctrl-C and termination paths. Each
+        transition therefore handles EXIT, INT, and TERM, keeps the trap until
+        its target mode is observed, and restores maintenance isolation if a
+        preceding mutation fails.
+        """
+        recipes = (
+            (
+                "mode-maintenance stage:",
+                "# Reconcile a stage to PARKED.",
+                "MAINTENANCE",
+            ),
+            (
+                "mode-parked stage:",
+                "# Reconcile existing stage infrastructure",
+                "PARKED",
+            ),
+            ("mode-live stage:", "# Report the reconciled lifecycle mode.", "LIVE"),
+        )
+
+        for start, end, target in recipes:
+            block = self._block_between(start, end)
+            assert "trap cleanup EXIT INT TERM" in block
+            assert "_enforce-maintenance" in block
+            assert "_mode-current" in block
+            assert f"did not converge to {target}" in block
+            assert "trap - EXIT INT TERM" in block
+
+    def test_maintenance_wrappers_preserve_isolation_on_every_exit(self):
+        """Maintenance-only operations may change resources but never exposure.
+
+        Infrastructure reconciliation, staged deployment, and management
+        commands each install full signal coverage before their first mutation
+        and verify that MAINTENANCE remains in force before removing cleanup.
+        """
+        init_block = self._block_between(
+            "init-stage-maintenance stage:",
+            "# Build and deploy the newest app revision",
+        )
+        deploy_block = self._block_between(
+            "deploy-maintenance stage:",
+            "# Run a Django management command during MAINTENANCE",
+        )
+        management_block = self._block_between(
+            "maintenance-management-cmd stage command:",
+            "# Reconcile a stage to LIVE.",
+        )
+
+        for block in (init_block, deploy_block, management_block):
+            assert block.index("_maintenance-assert-offline") < block.index(
+                "trap cleanup EXIT INT TERM",
+            )
+            assert "trap cleanup EXIT INT TERM" in block
+            assert "mode-maintenance" in block
+            assert "_mode-current" in block
+            assert "trap - EXIT INT TERM" in block
+        assert "GCP_INIT_STAGE_MAINTENANCE=1" in init_block
+
+    def test_parking_prompt_names_the_live_outage_and_database_stop(self):
+        """Parking confirmation must accurately describe its production impact.
+
+        The command itself first isolates runtime, so describing it as merely
+        stopping an already-isolated database would understate an invocation
+        made against a LIVE production stage.
+        """
+        block = self._block_between(
+            "mode-parked stage:",
+            "# Reconcile existing stage infrastructure",
+        )
+
+        assert "take LIVE PRODUCTION offline" in block
+        assert "stop Cloud SQL" in block
 
     def test_maintenance_enforcement_scales_every_runtime_surface_to_zero(self):
         """Maintenance isolates runtime and work without changing Cloud SQL.
@@ -916,6 +1061,21 @@ class GcpOperatorRecipeInvariantTests(SimpleTestCase):
         assert "MAINTENANCE_ERRORS" in block
         assert "completed all possible safeguards" in block
 
+    def test_maintenance_diagnostics_include_the_mcp_kill_switch_value(self):
+        """An MCP-only isolation failure must identify the hidden mismatch.
+
+        Internal ingress and zero capacity can look correct while an enabled
+        MCP container can still serve tools to internal callers. Printing the
+        effective `VALIDIBOT_MCP_ENABLED` value makes that failure actionable
+        instead of reporting three apparently healthy runtime fields.
+        """
+        block = self._block_between(
+            "_maintenance-assert-offline stage:",
+            "_enforce-maintenance stage:",
+        )
+
+        assert "VALIDIBOT_MCP_ENABLED=$mcp_enabled" in block
+
     def test_maintenance_park_is_the_only_explicit_database_stop_path(self):
         """Parking, and only parking, explicitly stops an isolated database.
 
@@ -925,7 +1085,7 @@ class GcpOperatorRecipeInvariantTests(SimpleTestCase):
         """
         block = self._block_between(
             "_maintenance-stop-database stage:",
-            "# Put a stage into maintenance mode",
+            "# Lifecycle states are reconciled rather than toggled.",
         )
 
         assert "_maintenance-assert-offline" in block
@@ -938,7 +1098,7 @@ class GcpOperatorRecipeInvariantTests(SimpleTestCase):
         assert '-z "$ACTIVE_OPERATION"' in block
         assert self._gcp_mod_text().count("--activation-policy NEVER") == 1
 
-    def test_maintenance_on_isolates_runtime_then_starts_database(self):
+    def test_mode_maintenance_isolates_runtime_then_starts_database(self):
         """Entering maintenance leaves an isolated stage ready for DB work.
 
         Runtime isolation must happen before Cloud SQL is made available. The
@@ -946,16 +1106,18 @@ class GcpOperatorRecipeInvariantTests(SimpleTestCase):
         parks the database implicitly.
         """
         block = self._block_between(
-            "maintenance-on stage:",
-            "# Park an already isolated stage",
+            "mode-maintenance stage:",
+            "# Reconcile a stage to PARKED.",
         )
 
         assert block.index("_enforce-maintenance") < block.index(
             "_maintenance-start-database"
         )
-        assert "trap 'just gcp _enforce-maintenance" in block
+        assert "trap cleanup EXIT INT TERM" in block
+        assert "trap - EXIT INT TERM" in block
         assert "_maintenance-stop-database" not in block
         assert "runtime isolated, work paused, database available" in block
+        assert "Cloud SQL is still running and billed" in block
 
     def test_maintenance_database_start_polls_provider_state_asynchronously(self):
         """A slow Cloud SQL control-plane operation must not defeat cleanup.
@@ -989,24 +1151,25 @@ class GcpOperatorRecipeInvariantTests(SimpleTestCase):
         """
         block = self._block_between(
             "deploy-maintenance stage:",
-            "# Run a Django management command during maintenance",
+            "# Run a Django management command during MAINTENANCE",
         )
 
         assert "_maintenance-assert-offline" in block
-        assert "trap 'just gcp _enforce-maintenance" in block
-        assert "_maintenance-start-database" in block
+        assert "trap cleanup EXIT INT TERM" in block
+        assert "mode-maintenance" in block
         assert "_maintenance-stop-database" not in block
         assert "_migrate" in block
         maintenance_safe_child_steps = 4
         assert block.count("GCP_DEPLOY_MAINTENANCE=1") == maintenance_safe_child_steps
-        assert "trap - EXIT" in block
+        assert "trap - EXIT INT TERM" in block
 
     def test_validator_database_commands_fail_fast_and_setup_enters_maintenance(self):
         """Validator reconciliation must not depend on accidental SQL starts.
 
         Read operations reject a stopped or transitioning database with a
-        concrete recovery command. First-time setup confirms its target before
-        entering maintenance, then performs its database-backed status check.
+        concrete diagnostic. First-time setup checks an existing installation
+        before changing a LIVE or MAINTENANCE stage; a PARKED stage needs an
+        isolated database start before that same read-only check can run.
         """
         status_block = self._block_between(
             "_validator-status-json stage output:",
@@ -1019,12 +1182,16 @@ class GcpOperatorRecipeInvariantTests(SimpleTestCase):
 
         assert "_maintenance-require-database" in status_block
         assert "Type the GCP project ID to continue" in setup_block
-        assert setup_block.index("maintenance-on") < setup_block.index(
-            "_validator-status-json"
+        assert "ensure_uninstalled" in setup_block
+        assert setup_block.index(
+            'if [ "$INITIAL_MODE" != "PARKED" ]',
+        ) < setup_block.index(
+            "mode-maintenance",
         )
-        assert "_enforce-maintenance" in setup_block
+        assert 'if [ "$INITIAL_MODE" = "PARKED" ]' in setup_block
+        assert "_mode-restore" in setup_block
 
-    def test_maintenance_off_waits_for_database_before_resuming_work(self):
+    def test_mode_live_waits_for_database_before_resuming_work(self):
         """No traffic or queued work may resume against a starting database.
 
         The database readiness helper must run before service ingress, queues,
@@ -1032,8 +1199,8 @@ class GcpOperatorRecipeInvariantTests(SimpleTestCase):
         so temporary maintenance scaling does not erase the chosen capacity.
         """
         block = self._block_between(
-            "maintenance-off stage:",
-            "# Report whether a stage is online",
+            "mode-live stage:",
+            "# Report the reconciled lifecycle mode.",
         )
 
         ready = block.index("_maintenance-start-database")
@@ -1045,13 +1212,20 @@ class GcpOperatorRecipeInvariantTests(SimpleTestCase):
         )
         assert "VALIDIBOT_MCP_ENABLED=$MCP_ENABLED" in block
         assert "desired-min-instances" in block
+        assert "trap cleanup EXIT INT TERM" in block
+        assert "did not converge to LIVE" in block
+        assert "CURRENT_MODE=$(just gcp _mode-current {{stage}})" in block
+        assert "is already LIVE" in block
+        assert block.index("trap cleanup EXIT INT TERM") < block.rindex(
+            "just gcp _enforce-maintenance {{stage}}",
+        )
 
     def test_mcp_maintenance_deploy_is_disabled_until_stage_reopens(self):
         """An offline MCP revision must not require the offline Django API.
 
         The FastMCP startup license gate calls Django whenever MCP is enabled.
         Maintenance deployment therefore stamps the kill switch off; the main
-        maintenance-off recipe restores the operator's configured value only
+        mode-live recipe restores the operator's configured value only
         after web ingress is public again.
         """
         mcp_module = (REPO_ROOT / "just" / "mcp" / "mod.just").read_text(

--- a/tests/test_validator_release_operator_contract.py
+++ b/tests/test_validator_release_operator_contract.py
@@ -144,6 +144,38 @@ def test_setup_and_multi_update_activate_selected_backends_as_one_group():
         assert 'management-cmd {{stage}} "$GROUP_COMMAND"' in recipe
 
 
+def test_validator_mutations_restore_the_mode_that_was_active_on_entry():
+    """Release work must not turn a parked or maintenance stage into LIVE.
+
+    Each operation records the complete lifecycle classification before its
+    first mutation, rejects an already partial transition, performs isolated
+    work in MAINTENANCE, and delegates restoration to the shared exact-mode
+    helper on both success and cleanup paths.
+    """
+    text = PUBLIC_GCP_RECIPES.read_text(encoding="utf-8")
+    recipes = (
+        _recipe(text, "validator-setup stage", "# Reconcile one backend"),
+        _recipe(
+            text,
+            'validator-update stage backend=""',
+            "# Roll back one backend",
+        ),
+        _recipe(
+            text,
+            'validator-rollback stage backend operation="release"',
+            "# Calculate an exact seven-day cleanup plan",
+        ),
+    )
+
+    for recipe in recipes:
+        assert "INITIAL_MODE=$(just gcp _mode-current {{stage}})" in recipe
+        assert "PARTIALLY_TRANSITIONED" in recipe
+        assert "trap" in recipe
+        assert "EXIT INT TERM" in recipe
+        assert "mode-maintenance {{stage}}" in recipe
+        assert '_mode-restore {{stage}} "$INITIAL_MODE"' in recipe
+
+
 def test_update_reverifies_and_round_trips_the_outgoing_release():
     """Candidate acceptance must prove the advertised rollback pair still works."""
 

--- a/validibot/core/tasks/registry.py
+++ b/validibot/core/tasks/registry.py
@@ -263,8 +263,7 @@ SCHEDULED_ADMIN_TASKS: tuple[ScheduledAdminTaskDefinition, ...] = (
 # Extension point for downstream packages (``validibot-cloud``,
 # ``validibot-pro``, ``validibot-enterprise``) to contribute their own
 # scheduled tasks. Community code never knows about these — a cloud-only
-# concern like "verify license-document hashes against stored
-# acceptances" has no business being in the public-repo registry.
+# concern has no business being in the public-repo registry.
 #
 # Downstream packages call ``register_scheduled_admin_task(...)`` from
 # their ``AppConfig.ready()``, mirroring how commercial packages call


### PR DESCRIPTION
## Summary

- define MAINTENANCE as isolated runtime with Cloud SQL available
- define PARKED as isolated runtime with Cloud SQL stopped
- add an explicit `just gcp maintenance-park <stage>` command
- make `maintenance-on` start Cloud SQL and leave it running
- stop maintenance deployment and management commands from repeatedly stopping SQL
- preserve runtime isolation through failure traps without changing database state
- make validator database operations fail fast with a clear `maintenance-on` instruction
- report ONLINE, MAINTENANCE, PARKED, and PARTIALLY TRANSITIONED states accurately
- update operator documentation for the revised lifecycle

## Rationale

Maintenance operations such as deployment, migrations, validator installation, and management commands need the database. Automatically stopping Cloud SQL after each operation caused unnecessary stop/start/stop cycles and long waits.

Database shutdown is now an explicit parking operation for extended idle periods.

## Verification

- `uv lock --check`
- `uv run ruff check tests/test_self_hosted_kit.py`
- `uv run ruff format --check tests/test_self_hosted_kit.py`
- `uv run pytest tests/test_self_hosted_kit.py` — 106 passed
- `git diff --check`
- Justfile recipe parsing